### PR TITLE
Added the ability to parse any functions

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,8 +1,8 @@
 use crate::types::{
-    Attribute, Enum, EnumDiscriminant, EnumVariant, GenericParams, NamedField, Struct,
-    StructFields, TupleField, TyExpr, TypeDeclaration, VisMarker, WhereClauses, Function, FunctionParameter,
+    Attribute, Enum, EnumDiscriminant, EnumVariant, Function, FunctionParameter, GenericParams,
+    NamedField, Struct, StructFields, TupleField, TyExpr, TypeDeclaration, VisMarker, WhereClauses,
 };
-use proc_macro2::{Delimiter, Ident, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Ident, TokenStream, TokenTree, Span};
 use std::iter::Peekable;
 
 type TokenIter = Peekable<proc_macro2::token_stream::IntoIter>;
@@ -289,6 +289,7 @@ fn parse_fn_params(tokens: TokenStream) -> Vec<FunctionParameter> {
         if tokens.peek().is_none() {
             break;
         }
+        let attributes = consume_attributes(&mut tokens);
 
         let ident = parse_ident(tokens.next().unwrap()).unwrap();
 
@@ -299,6 +300,7 @@ fn parse_fn_params(tokens: TokenStream) -> Vec<FunctionParameter> {
 
         tokens.peek().unwrap();
         fields.push(FunctionParameter {
+            attributes,
             name: ident,
             ty: TyExpr {
                 tokens: consume_field_type(&mut tokens),
@@ -400,19 +402,60 @@ pub fn parse_type(tokens: TokenStream) -> TypeDeclaration {
                 where_clauses,
                 variants: enum_variants,
             })
-        } else if ident == "fn" {
+        } else if matches!(ident.to_string().as_str(), "extern" | "fn" | "const" | "unsafe" | "async") {
+
+            let (abi, is_unsafe, is_async, is_const) = if !(ident.to_string() == "fn") {
+                let mut abi = String::from("Rust"); // Default ABI
+                let mut is_unsafe = false;
+                let mut is_async = false;
+                let mut is_const = false;
+                let mut chars;
+                let mut next = Some(ident); // Can't be in the loop due to abnormal default value
+                loop {
+                    if let Some(i) = next {
+                        // Due to some reason unknown to me, identifiers hide their name behind a private field
+                        if i == "extern" {
+                            let next = tokens.next().unwrap(); // There must be another one
+                            if let TokenTree::Literal(x) = next {
+                                // The ABI is in the format "\"C\"", we want "C"
+                                // This is a very stupid borrow checker trick. It works and does not cost memory. It just looks dumb
+                                    chars = x.to_string();
+                                    let mut y = chars.chars();
+                                    y.next();
+                                    y.next_back();
+                                    // Convert back into a string
+                                    abi = y.as_str().to_string();
+                            } else {
+                                panic!("invalid extern function attribute")
+                            }
+                        } else if i == "unsafe" {
+                            is_unsafe = true;
+                        } else if i == "async" {
+                            is_async = true;
+                        } else if i == "const" {
+                            is_const = true;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        unreachable!(); // After any keyword, there *must* be an identifier such as the function name
+                        break;
+                    }
+                    next = parse_ident(tokens.next().unwrap());
+                }
+                (abi, is_unsafe, is_async, is_const)
+            } else { ("Rust".to_string(), false, false, false) };
             let fn_name = parse_ident(tokens.next().unwrap()).unwrap();
 
             let generic_params = consume_generic_params(&mut tokens);
-            
+
             let next_token = tokens.next().unwrap();
             let params = match next_token {
                 TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {
                     parse_fn_params(group.stream())
                 }
-                _ => panic!("detected unknown function deceleration: expected fn x(params). Something went wrong with the brackets, found {}", next_token)
+                _ => panic!("detected unknown function deceleration: expected fn x(params). Something went wrong with the brackets, found {} .. {}", next_token.to_string(), fn_name)
             };
-            
 
             let next_token = tokens.next().unwrap();
             let return_type = match next_token {
@@ -421,26 +464,27 @@ pub fn parse_type(tokens: TokenStream) -> TypeDeclaration {
                         if !(x.as_char() == '>') {
                             panic!("Expected function deceleration fn x() -> y or fn x(), found fn x() -");
                         }
-                        Some(
-                            TyExpr {
-                                tokens: (consume_stuff_until(&mut tokens, |token| match token {
-                                    TokenTree::Group(group) if group.delimiter() == Delimiter::Brace => true,
-                                    TokenTree::Ident(i) if i == &Ident::new("where", i.span()) => true,
-                                    TokenTree::Punct(punct) if punct.as_char() == ';' => true,
-                                    _ => false})),
-                            },
-                        )
-                    } else { None }
+                        Some(TyExpr {
+                            tokens: (consume_stuff_until(&mut tokens, |token| match token {
+                                TokenTree::Group(group)
+                                    if group.delimiter() == Delimiter::Brace =>
+                                {
+                                    true
+                                }
+                                TokenTree::Ident(i) if i == &Ident::new("where", i.span()) => true,
+                                TokenTree::Punct(punct) if punct.as_char() == ';' => true,
+                                _ => false,
+                            })),
+                        })
+                    } else {
+                        None
+                    }
                 }
-                TokenTree::Group(group) if group.delimiter() == Delimiter::Brace => {
-                    None
-                }
+                TokenTree::Group(group) if group.delimiter() == Delimiter::Brace => None,
                 _ => panic!("cannot parse type"),
             };
 
             let where_clauses = consume_where_clauses(&mut tokens);
-
-
 
             TypeDeclaration::Function(Function {
                 attributes,
@@ -450,6 +494,10 @@ pub fn parse_type(tokens: TokenStream) -> TypeDeclaration {
                 where_clauses,
                 params,
                 returns: return_type,
+                is_async,
+                is_unsafe,
+                is_const,
+                abi: abi.to_string(),
             })
         } else if ident == "union" {
             panic!("cannot parse unions")

--- a/src/snapshots/venial__tests__parse_all_kw_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_all_kw_fn_definitions.snap
@@ -4,14 +4,12 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            all_kw,
         ),
         generic_params: None,
         where_clauses: None,
@@ -19,17 +17,17 @@ Function(
             FunctionParameter {
                 attributes: [],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
         returns: None,
-        abi: "Rust",
-        is_unsafe: false,
-        is_async: false,
-        is_const: false,
+        abi: "C",
+        is_unsafe: true,
+        is_async: true,
+        is_const: true,
     },
 )

--- a/src/snapshots/venial__tests__parse_async_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_async_fn_definitions.snap
@@ -4,14 +4,12 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            async_fn,
         ),
         generic_params: None,
         where_clauses: None,
@@ -19,17 +17,17 @@ Function(
             FunctionParameter {
                 attributes: [],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
         returns: None,
         abi: "Rust",
         is_unsafe: false,
-        is_async: false,
+        is_async: true,
         is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_attr_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_attr_fn_definitions.snap
@@ -1,0 +1,30 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [
+            #[
+                "my_attr",
+            ],
+        ],
+        vis_marker: None,
+        name: Ident(
+            my_attr_fn,
+        ),
+        generic_params: None,
+        where_clauses: None,
+        params: [
+            FunctionParameter {
+                name: Ident(
+                    a,
+                ),
+                ty: [
+                    "i32",
+                ],
+            },
+        ],
+        returns: None,
+    },
+)

--- a/src/snapshots/venial__tests__parse_const_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_const_fn_definitions.snap
@@ -4,14 +4,12 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            const_fn,
         ),
         generic_params: None,
         where_clauses: None,
@@ -19,10 +17,10 @@ Function(
             FunctionParameter {
                 attributes: [],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
@@ -30,6 +28,6 @@ Function(
         abi: "Rust",
         is_unsafe: false,
         is_async: false,
-        is_const: false,
+        is_const: true,
     },
 )

--- a/src/snapshots/venial__tests__parse_empty_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_empty_fn_definitions.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        name: Ident(
+            test_me,
+        ),
+        generic_params: None,
+        where_clauses: None,
+        params: [],
+        returns: None,
+    },
+)

--- a/src/snapshots/venial__tests__parse_empty_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_empty_fn_definitions.snap
@@ -13,5 +13,9 @@ Function(
         where_clauses: None,
         params: [],
         returns: None,
+        abi: "Rust",
+        is_unsafe: false,
+        is_async: false,
+        is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_extern_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_extern_fn_definitions.snap
@@ -4,14 +4,12 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            extern_fn,
         ),
         generic_params: None,
         where_clauses: None,
@@ -19,15 +17,15 @@ Function(
             FunctionParameter {
                 attributes: [],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
         returns: None,
-        abi: "Rust",
+        abi: "C",
         is_unsafe: false,
         is_async: false,
         is_const: false,

--- a/src/snapshots/venial__tests__parse_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_fn_definitions.snap
@@ -1,0 +1,38 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        name: Ident(
+            hello,
+        ),
+        generic_params: None,
+        where_clauses: None,
+        params: [
+            FunctionParameter {
+                name: Ident(
+                    a,
+                ),
+                ty: [
+                    "i32",
+                ],
+            },
+            FunctionParameter {
+                name: Ident(
+                    b,
+                ),
+                ty: [
+                    "f32",
+                ],
+            },
+        ],
+        returns: Some(
+            [
+                "String",
+            ],
+        ),
+    },
+)

--- a/src/snapshots/venial__tests__parse_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_fn_definitions.snap
@@ -13,6 +13,7 @@ Function(
         where_clauses: None,
         params: [
             FunctionParameter {
+                attributes: [],
                 name: Ident(
                     a,
                 ),
@@ -21,6 +22,7 @@ Function(
                 ],
             },
             FunctionParameter {
+                attributes: [],
                 name: Ident(
                     b,
                 ),
@@ -34,5 +36,9 @@ Function(
                 "String",
             ],
         ),
+        abi: "Rust",
+        is_unsafe: false,
+        is_async: false,
+        is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_generic_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_generic_fn_definitions.snap
@@ -21,6 +21,7 @@ Function(
         where_clauses: None,
         params: [
             FunctionParameter {
+                attributes: [],
                 name: Ident(
                     a,
                 ),
@@ -34,5 +35,9 @@ Function(
                 "B",
             ],
         ),
+        abi: "Rust",
+        is_unsafe: false,
+        is_async: false,
+        is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_generic_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_generic_fn_definitions.snap
@@ -1,0 +1,38 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        name: Ident(
+            generic,
+        ),
+        generic_params: Some(
+            [
+                "<",
+                "T",
+                ",",
+                "B",
+                ">",
+            ],
+        ),
+        where_clauses: None,
+        params: [
+            FunctionParameter {
+                name: Ident(
+                    a,
+                ),
+                ty: [
+                    "T",
+                ],
+            },
+        ],
+        returns: Some(
+            [
+                "B",
+            ],
+        ),
+    },
+)

--- a/src/snapshots/venial__tests__parse_param_attr_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_param_attr_fn_definitions.snap
@@ -4,32 +4,34 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            visibility,
         ),
         generic_params: None,
         where_clauses: None,
         params: [
             FunctionParameter {
-                attributes: [],
+                attributes: [
+                    #[
+                        "my_attr",
+                    ],
+                ],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
         returns: None,
         abi: "Rust",
         is_unsafe: false,
-        is_async: false,
+        is_async: true,
         is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_unsafe_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_unsafe_fn_definitions.snap
@@ -4,14 +4,12 @@ expression: func
 ---
 Function(
     Function {
-        attributes: [
-            #[
-                "my_attr",
-            ],
-        ],
-        vis_marker: None,
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
         name: Ident(
-            my_attr_fn,
+            unsafe_fn,
         ),
         generic_params: None,
         where_clauses: None,
@@ -19,16 +17,16 @@ Function(
             FunctionParameter {
                 attributes: [],
                 name: Ident(
-                    a,
+                    b,
                 ),
                 ty: [
-                    "i32",
+                    "f32",
                 ],
             },
         ],
         returns: None,
         abi: "Rust",
-        is_unsafe: false,
+        is_unsafe: true,
         is_async: false,
         is_const: false,
     },

--- a/src/snapshots/venial__tests__parse_visi_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_visi_fn_definitions.snap
@@ -15,6 +15,7 @@ Function(
         where_clauses: None,
         params: [
             FunctionParameter {
+                attributes: [],
                 name: Ident(
                     b,
                 ),
@@ -24,5 +25,9 @@ Function(
             },
         ],
         returns: None,
+        abi: "Rust",
+        is_unsafe: false,
+        is_async: false,
+        is_const: false,
     },
 )

--- a/src/snapshots/venial__tests__parse_visi_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_visi_fn_definitions.snap
@@ -1,0 +1,28 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: Some(
+            pub,
+        ),
+        name: Ident(
+            visibility,
+        ),
+        generic_params: None,
+        where_clauses: None,
+        params: [
+            FunctionParameter {
+                name: Ident(
+                    b,
+                ),
+                ty: [
+                    "f32",
+                ],
+            },
+        ],
+        returns: None,
+    },
+)

--- a/src/snapshots/venial__tests__parse_where_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_where_fn_definitions.snap
@@ -1,0 +1,34 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        name: Ident(
+            where_clause,
+        ),
+        generic_params: Some(
+            [
+                "<",
+                "T",
+                ">",
+            ],
+        ),
+        where_clauses: Some(
+            [
+                "where",
+                "T",
+                ":",
+                "Debug",
+            ],
+        ),
+        params: [],
+        returns: Some(
+            [
+                "T",
+            ],
+        ),
+    },
+)

--- a/src/snapshots/venial__tests__parse_where_fn_definitions.snap
+++ b/src/snapshots/venial__tests__parse_where_fn_definitions.snap
@@ -30,5 +30,9 @@ Function(
                 "T",
             ],
         ),
+        abi: "Rust",
+        is_unsafe: false,
+        is_async: false,
+        is_const: false,
     },
 )

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -459,3 +459,61 @@ fn parse_multiple_brackets() {
 
     assert_debug_snapshot!(struct_type);
 }
+
+#[test]
+fn parse_fn_definitions() {
+    let func = parse_type(quote! {
+        fn hello(a: i32, b: f32) -> String {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_empty_fn_definitions() {
+    let func = parse_type(quote! {
+        fn test_me() {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_generic_fn_definitions() {
+    let func = parse_type(quote! {
+        fn generic<T, B>(a: T) -> B {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_where_fn_definitions() {
+    let func = parse_type(quote! {
+        fn where_clause<T>() -> T
+        where
+            T: Debug
+        {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_attr_fn_definitions() {
+    let func = parse_type(quote! {
+        #[my_attr]
+        fn my_attr_fn(a: i32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_visi_fn_definitions() {
+    let func = parse_type(quote! {
+        pub fn visibility(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -517,3 +517,57 @@ fn parse_visi_fn_definitions() {
 
     assert_debug_snapshot!(func);
 }
+
+#[test]
+fn parse_extern_fn_definitions() {
+    let func = parse_type(quote! {
+        pub extern "C" fn extern_fn(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_const_fn_definitions() {
+    let func = parse_type(quote! {
+        pub const fn const_fn(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_async_fn_definitions() {
+    let func = parse_type(quote! {
+        pub async fn async_fn(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_unsafe_fn_definitions() {
+    let func = parse_type(quote! {
+        pub unsafe fn unsafe_fn(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_all_kw_fn_definitions() {
+    let func = parse_type(quote! {
+        pub async const unsafe extern "C" fn all_kw(b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_param_attr_fn_definitions() {
+    let func = parse_type(quote! {
+        pub async fn visibility(#[my_attr] b: f32) {}
+    });
+
+    assert_debug_snapshot!(func);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -212,6 +212,7 @@ pub struct EnumDiscriminant {
 /// ```
 #[derive(Clone, Debug)]
 pub struct FunctionParameter {
+    pub attributes: Vec<Attribute>,
     pub name: Ident,
     pub ty: TyExpr,
 }
@@ -232,9 +233,12 @@ pub struct Function {
     pub generic_params: Option<GenericParams>,
     pub where_clauses: Option<WhereClauses>,
     pub params: Vec<FunctionParameter>,
-    pub returns: Option<TyExpr>
+    pub returns: Option<TyExpr>,
+    pub abi: String,
+    pub is_unsafe: bool,
+    pub is_async: bool,
+    pub is_const: bool,
 }
-
 
 // ---
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ use proc_macro2::{Ident, TokenTree};
 pub enum TypeDeclaration {
     Struct(Struct),
     Enum(Enum),
+    Function(Function),
 }
 
 // TODO - fn TypeDeclaration::name()
@@ -201,6 +202,39 @@ pub struct TyExpr {
 pub struct EnumDiscriminant {
     pub tokens: Vec<TokenTree>,
 }
+
+/// A parameter of a [`Function`]
+///
+/// For instance, in the following code, `a` and `b` are both function parameters
+///
+/// ```no_run
+/// pub fn hello_world(a: i32, b: f32) {}
+/// ```
+#[derive(Clone, Debug)]
+pub struct FunctionParameter {
+    pub name: Ident,
+    pub ty: TyExpr,
+}
+
+/// Declaration of a function.
+///
+/// **Example input:**
+///
+/// ```no_run
+/// fn hello(a: i32, b: f32) -> f32 { return 0.0; }
+/// fn eval(c: String, b: i32) { return; }
+/// ```
+#[derive(Clone, Debug)]
+pub struct Function {
+    pub attributes: Vec<Attribute>,
+    pub vis_marker: Option<VisMarker>,
+    pub name: Ident,
+    pub generic_params: Option<GenericParams>,
+    pub where_clauses: Option<WhereClauses>,
+    pub params: Vec<FunctionParameter>,
+    pub returns: Option<TyExpr>
+}
+
 
 // ---
 


### PR DESCRIPTION
This pull request adds functions that enable the parsing of any function, as demonstrated in the `tests.rs` file. This will allow this crate to be used for serious projects which use function attributes (such as: various web frameworks) in the future. 

The following is just copy-pasted from the `tests.rs` file and showcases what this new feature can parse:
```rs
fn hello(a: i32, b: f32) -> String {}
fn test_me() {}
fn generic<T, B>(a: T) -> B {}
fn where_clause<T>() -> T
where
    T: Debug
{}
#[my_attr]
fn my_attr_fn(a: i32) {}
pub fn visibility(b: f32) {}
```