### PR TITLE
Add `DerefMut` for `Punctuated`

### DIFF
--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -113,3 +113,9 @@ impl<T> std::ops::Deref for Punctuated<T> {
         &self.inner
     }
 }
+
+impl<T> std::ops::DerefMut for Punctuated<T> {
+    fn deref_mut(&mut self) -> &mut <Self as std::ops::Deref>::Target {
+        &mut self.inner
+    }
+}


### PR DESCRIPTION
Necessary for writing code like
```rust
let mut modify: Punctuated<T> = …;
for (v, _p) in modify.iter_mut() {
    *v = …;
}
```
(My current workaround is to clone everything, modify, push it to a new punctuated, and then replace the old punctuated.)