### PR TITLE
Support function receivers `self`, `mut self`, `&self`, `&mut self`

### DIFF
--- a/src/snapshots/venial__tests__parse_all_kw_fn.snap
+++ b/src/snapshots/venial__tests__parse_all_kw_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 671
 expression: func
 ---
 Function(
@@ -45,18 +44,24 @@ Function(
             all_kw,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_all_kw_fn.snap
+++ b/src/snapshots/venial__tests__parse_all_kw_fn.snap
@@ -46,19 +46,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_async_fn.snap
+++ b/src/snapshots/venial__tests__parse_async_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 635
 expression: func
 ---
 Function(
@@ -25,18 +24,24 @@ Function(
             async_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_async_fn.snap
+++ b/src/snapshots/venial__tests__parse_async_fn.snap
@@ -26,19 +26,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_attr_fn.snap
+++ b/src/snapshots/venial__tests__parse_attr_fn.snap
@@ -32,19 +32,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    a,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        a,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
                 },
-                ty: [
-                    i32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_attr_fn.snap
+++ b/src/snapshots/venial__tests__parse_attr_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 717
 expression: func
 ---
 Function(
@@ -31,18 +30,24 @@ Function(
             my_attr_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     a,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     i32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_const_fn.snap
+++ b/src/snapshots/venial__tests__parse_const_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 626
 expression: func
 ---
 Function(
@@ -25,18 +24,24 @@ Function(
             const_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_const_fn.snap
+++ b/src/snapshots/venial__tests__parse_const_fn.snap
@@ -26,19 +26,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_default_fn.snap
+++ b/src/snapshots/venial__tests__parse_default_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 617
 expression: func
 ---
 Function(
@@ -25,18 +24,24 @@ Function(
             default_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_default_fn.snap
+++ b/src/snapshots/venial__tests__parse_default_fn.snap
@@ -26,19 +26,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_empty_fn.snap
+++ b/src/snapshots/venial__tests__parse_empty_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 561
 expression: func
 ---
 Function(
@@ -19,8 +18,10 @@ Function(
             test_me,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_extern_abi_fn.snap
+++ b/src/snapshots/venial__tests__parse_extern_abi_fn.snap
@@ -30,19 +30,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_extern_abi_fn.snap
+++ b/src/snapshots/venial__tests__parse_extern_abi_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 653
 expression: func
 ---
 Function(
@@ -29,18 +28,24 @@ Function(
             extern_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_extern_fn.snap
+++ b/src/snapshots/venial__tests__parse_extern_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 662
 expression: func
 ---
 Function(
@@ -25,18 +24,24 @@ Function(
             extern_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_extern_fn.snap
+++ b/src/snapshots/venial__tests__parse_extern_fn.snap
@@ -26,19 +26,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_fn.snap
+++ b/src/snapshots/venial__tests__parse_fn.snap
@@ -20,32 +20,38 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    a,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        a,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
                 },
-                ty: [
-                    i32,
-                ],
-            },
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            ),
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: Some(

--- a/src/snapshots/venial__tests__parse_fn.snap
+++ b/src/snapshots/venial__tests__parse_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 552
 expression: func
 ---
 Function(
@@ -19,12 +18,17 @@ Function(
             hello,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     a,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     i32,
                 ],
@@ -34,12 +38,28 @@ Function(
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: Some(
+            [
+                Punct {
+                    char: '-',
+                    spacing: Joint,
+                },
+                Punct {
+                    char: '>',
+                    spacing: Alone,
+                },
+            ],
+        ),
         return_ty: Some(
             [
                 String,

--- a/src/snapshots/venial__tests__parse_fn_body.snap
+++ b/src/snapshots/venial__tests__parse_fn_body.snap
@@ -20,32 +20,38 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    a,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        a,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
                 },
-                ty: [
-                    i32,
-                ],
-            },
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            ),
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: Some(

--- a/src/snapshots/venial__tests__parse_fn_body.snap
+++ b/src/snapshots/venial__tests__parse_fn_body.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 691
 expression: func
 ---
 Function(
@@ -19,12 +18,17 @@ Function(
             hello_world,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     a,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     i32,
                 ],
@@ -34,12 +38,28 @@ Function(
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: Some(
+            [
+                Punct {
+                    char: '-',
+                    spacing: Joint,
+                },
+                Punct {
+                    char: '>',
+                    spacing: Alone,
+                },
+            ],
+        ),
         return_ty: Some(
             [
                 String,

--- a/src/snapshots/venial__tests__parse_fn_prototype.snap
+++ b/src/snapshots/venial__tests__parse_fn_prototype.snap
@@ -20,32 +20,38 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    a,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        a,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
                 },
-                ty: [
-                    i32,
-                ],
-            },
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            ),
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: Some(

--- a/src/snapshots/venial__tests__parse_fn_prototype.snap
+++ b/src/snapshots/venial__tests__parse_fn_prototype.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 700
 expression: func
 ---
 Function(
@@ -19,12 +18,17 @@ Function(
             prototype,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     a,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     i32,
                 ],
@@ -34,12 +38,28 @@ Function(
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: Some(
+            [
+                Punct {
+                    char: '-',
+                    spacing: Joint,
+                },
+                Punct {
+                    char: '>',
+                    spacing: Alone,
+                },
+            ],
+        ),
         return_ty: Some(
             [
                 String,

--- a/src/snapshots/venial__tests__parse_fn_self_param-2.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-2.snap
@@ -1,0 +1,51 @@
+---
+source: src/tests.rs
+expression: func_ref_self
+---
+Ok(
+    Function(
+        Function {
+            attributes: [],
+            vis_marker: None,
+            qualifiers: FunctionQualifiers {
+                tk_default: None,
+                tk_const: None,
+                tk_async: None,
+                tk_unsafe: None,
+                tk_extern: None,
+                extern_abi: None,
+            },
+            name: Ident(
+                foobar,
+            ),
+            generic_params: None,
+            tk_params_parens: (),
+            params: [
+                Receiver(
+                    FunctionReceiverParameter {
+                        attributes: [],
+                        tk_ref: Some(
+                            Punct {
+                                char: '&',
+                                spacing: Alone,
+                            },
+                        ),
+                        tk_mut: None,
+                        tk_self: Ident(
+                            self,
+                        ),
+                    },
+                ),
+            ],
+            where_clause: None,
+            tk_return_arrow: None,
+            return_ty: None,
+            body: Some(
+                Group {
+                    delimiter: Brace,
+                    stream: TokenStream [],
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/venial__tests__parse_fn_self_param-3.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-3.snap
@@ -1,0 +1,50 @@
+---
+source: src/tests.rs
+expression: func_mut_self
+---
+Ok(
+    Function(
+        Function {
+            attributes: [],
+            vis_marker: None,
+            qualifiers: FunctionQualifiers {
+                tk_default: None,
+                tk_const: None,
+                tk_async: None,
+                tk_unsafe: None,
+                tk_extern: None,
+                extern_abi: None,
+            },
+            name: Ident(
+                foobar,
+            ),
+            generic_params: None,
+            tk_params_parens: (),
+            params: [
+                Receiver(
+                    FunctionReceiverParameter {
+                        attributes: [],
+                        tk_ref: None,
+                        tk_mut: Some(
+                            Ident(
+                                mut,
+                            ),
+                        ),
+                        tk_self: Ident(
+                            self,
+                        ),
+                    },
+                ),
+            ],
+            where_clause: None,
+            tk_return_arrow: None,
+            return_ty: None,
+            body: Some(
+                Group {
+                    delimiter: Brace,
+                    stream: TokenStream [],
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/venial__tests__parse_fn_self_param-4.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-4.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests.rs
+expression: func_ref_mut_self
+---
+Ok(
+    Function(
+        Function {
+            attributes: [],
+            vis_marker: None,
+            qualifiers: FunctionQualifiers {
+                tk_default: None,
+                tk_const: None,
+                tk_async: None,
+                tk_unsafe: None,
+                tk_extern: None,
+                extern_abi: None,
+            },
+            name: Ident(
+                foobar,
+            ),
+            generic_params: None,
+            tk_params_parens: (),
+            params: [
+                Receiver(
+                    FunctionReceiverParameter {
+                        attributes: [],
+                        tk_ref: Some(
+                            Punct {
+                                char: '&',
+                                spacing: Alone,
+                            },
+                        ),
+                        tk_mut: Some(
+                            Ident(
+                                mut,
+                            ),
+                        ),
+                        tk_self: Ident(
+                            self,
+                        ),
+                    },
+                ),
+            ],
+            where_clause: None,
+            tk_return_arrow: None,
+            return_ty: None,
+            body: Some(
+                Group {
+                    delimiter: Brace,
+                    stream: TokenStream [],
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/venial__tests__parse_fn_self_param.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param.snap
@@ -1,0 +1,46 @@
+---
+source: src/tests.rs
+expression: func_self
+---
+Ok(
+    Function(
+        Function {
+            attributes: [],
+            vis_marker: None,
+            qualifiers: FunctionQualifiers {
+                tk_default: None,
+                tk_const: None,
+                tk_async: None,
+                tk_unsafe: None,
+                tk_extern: None,
+                extern_abi: None,
+            },
+            name: Ident(
+                foobar,
+            ),
+            generic_params: None,
+            tk_params_parens: (),
+            params: [
+                Receiver(
+                    FunctionReceiverParameter {
+                        attributes: [],
+                        tk_ref: None,
+                        tk_mut: None,
+                        tk_self: Ident(
+                            self,
+                        ),
+                    },
+                ),
+            ],
+            where_clause: None,
+            tk_return_arrow: None,
+            return_ty: None,
+            body: Some(
+                Group {
+                    delimiter: Brace,
+                    stream: TokenStream [],
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/venial__tests__parse_generic_fn.snap
+++ b/src/snapshots/venial__tests__parse_generic_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 570
 expression: func
 ---
 Function(
@@ -30,18 +29,35 @@ Function(
                 },
             ],
         ),
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     a,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     T,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: Some(
+            [
+                Punct {
+                    char: '-',
+                    spacing: Joint,
+                },
+                Punct {
+                    char: '>',
+                    spacing: Alone,
+                },
+            ],
+        ),
         return_ty: Some(
             [
                 B,

--- a/src/snapshots/venial__tests__parse_generic_fn.snap
+++ b/src/snapshots/venial__tests__parse_generic_fn.snap
@@ -31,19 +31,22 @@ Function(
         ),
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    a,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        a,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        T,
+                    ],
                 },
-                ty: [
-                    T,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: Some(

--- a/src/snapshots/venial__tests__parse_param_attr_fn.snap
+++ b/src/snapshots/venial__tests__parse_param_attr_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 798
 expression: func
 ---
 Function(
@@ -25,6 +24,7 @@ Function(
             visibility,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [
@@ -43,12 +43,17 @@ Function(
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_param_attr_fn.snap
+++ b/src/snapshots/venial__tests__parse_param_attr_fn.snap
@@ -26,31 +26,34 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [
-                    Attribute {
-                        tk_hashbang: Punct {
-                            char: '#',
-                            spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [
+                        Attribute {
+                            tk_hashbang: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                my_attr,
+                            ],
+                            value: Empty,
                         },
-                        tk_brackets: [],
-                        path: [
-                            my_attr,
-                        ],
-                        value: Empty,
+                    ],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
                     },
-                ],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_unsafe_fn.snap
+++ b/src/snapshots/venial__tests__parse_unsafe_fn.snap
@@ -26,19 +26,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_unsafe_fn.snap
+++ b/src/snapshots/venial__tests__parse_unsafe_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 644
 expression: func
 ---
 Function(
@@ -25,18 +24,24 @@ Function(
             unsafe_fn,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_visi_fn.snap
+++ b/src/snapshots/venial__tests__parse_visi_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 608
 expression: func
 ---
 Function(
@@ -21,18 +20,24 @@ Function(
             visibility,
         ),
         generic_params: None,
+        tk_params_parens: (),
         params: [
             FunctionParameter {
                 attributes: [],
                 name: Ident(
                     b,
                 ),
+                tk_colon: Punct {
+                    char: ':',
+                    spacing: Alone,
+                },
                 ty: [
                     f32,
                 ],
             },
         ],
         where_clause: None,
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_visi_fn.snap
+++ b/src/snapshots/venial__tests__parse_visi_fn.snap
@@ -22,19 +22,22 @@ Function(
         generic_params: None,
         tk_params_parens: (),
         params: [
-            FunctionParameter {
-                attributes: [],
-                name: Ident(
-                    b,
-                ),
-                tk_colon: Punct {
-                    char: ':',
-                    spacing: Alone,
+            Typed(
+                FunctionTypedParameter {
+                    attributes: [],
+                    tk_mut: None,
+                    name: Ident(
+                        b,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        f32,
+                    ],
                 },
-                ty: [
-                    f32,
-                ],
-            },
+            ),
         ],
         where_clause: None,
         tk_return_arrow: None,

--- a/src/snapshots/venial__tests__parse_where_fn-2.snap
+++ b/src/snapshots/venial__tests__parse_where_fn-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 589
 expression: func_2
 ---
 Function(
@@ -26,6 +25,7 @@ Function(
                 },
             ],
         ),
+        tk_params_parens: (),
         params: [],
         where_clause: Some(
             [
@@ -36,6 +36,7 @@ Function(
                 ],
             ],
         ),
+        tk_return_arrow: None,
         return_ty: None,
         body: Some(
             Group {

--- a/src/snapshots/venial__tests__parse_where_fn.snap
+++ b/src/snapshots/venial__tests__parse_where_fn.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests.rs
-assertion_line: 588
 expression: func
 ---
 Function(
@@ -26,6 +25,7 @@ Function(
                 },
             ],
         ),
+        tk_params_parens: (),
         params: [],
         where_clause: Some(
             [
@@ -34,6 +34,18 @@ Function(
                     ":",
                     Debug,
                 ],
+            ],
+        ),
+        tk_return_arrow: Some(
+            [
+                Punct {
+                    char: '-',
+                    spacing: Joint,
+                },
+                Punct {
+                    char: '>',
+                    spacing: Alone,
+                },
             ],
         ),
         return_ty: Some(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -814,27 +814,25 @@ fn parse_fn_no_pattern() {
     assert_debug_snapshot!(func);
 }
 
-// FIXME
 #[test]
-#[should_panic]
 fn parse_fn_self_param() {
-    let func_0 = parse_declaration(quote! {
+    let func_self = parse_declaration(quote! {
         fn foobar(self) {}
     });
-    let func_1 = parse_declaration(quote! {
+    let func_ref_self = parse_declaration(quote! {
         fn foobar(&self) {}
     });
-    let func_2 = parse_declaration(quote! {
+    let func_mut_self = parse_declaration(quote! {
         fn foobar(mut self) {}
     });
-    let func_3 = parse_declaration(quote! {
+    let func_ref_mut_self = parse_declaration(quote! {
         fn foobar(&mut self) {}
     });
 
-    assert_debug_snapshot!(func_0);
-    assert_debug_snapshot!(func_1);
-    assert_debug_snapshot!(func_2);
-    assert_debug_snapshot!(func_3);
+    assert_debug_snapshot!(func_self);
+    assert_debug_snapshot!(func_ref_self);
+    assert_debug_snapshot!(func_mut_self);
+    assert_debug_snapshot!(func_ref_mut_self);
 }
 
 // ============


### PR DESCRIPTION
Adds support for receiver parameters `self`, `mut self`, `&self`, `&mut self`.

Also captures several "non-content" tokens like `( )` parameter list group, `:` parameter name-value separator, `->` return type separator.

This PR contains **breaking changes**, as it splits `FunctionParameter` up:
```rust
#[derive(Clone, Debug)]
pub enum FunctionParameter {
    Receiver(FunctionReceiverParameter),
    Typed(FunctionTypedParameter),
}

// self, mut self, &self, &mut self
#[derive(Clone, Debug)]
pub struct FunctionReceiverParameter {
    pub attributes: Vec<Attribute>,
    pub tk_ref: Option<Punct>,
    pub tk_mut: Option<Ident>,
    pub tk_self: Ident,
}

// name: type
#[derive(Clone, Debug)]
pub struct FunctionTypedParameter {
    pub attributes: Vec<Attribute>,
    pub tk_mut: Option<Ident>,
    pub name: Ident,
    pub tk_colon: Punct,
    pub ty: TyExpr,
}
```