### PR TITLE
Fix parsing for `#![inner]` attributes followed by `#[outer]` ones

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,7 +4,7 @@ use crate::parse_type::{
     consume_declaration_name, consume_generic_params, consume_where_clause, parse_enum_variants,
     parse_named_fields, parse_tuple_fields,
 };
-use crate::parse_utils::{consume_attributes, consume_stuff_until, consume_vis_marker};
+use crate::parse_utils::{consume_outer_attributes, consume_stuff_until, consume_vis_marker};
 use crate::types::{Declaration, Enum, Impl, Struct, StructFields, Union};
 use crate::types_edition::GroupSpan;
 use crate::{ImplMember, TyExpr};
@@ -57,7 +57,7 @@ use proc_macro2::{Delimiter, TokenStream, TokenTree};
 pub fn parse_declaration(tokens: TokenStream) -> Result<Declaration, Error> {
     let mut tokens = tokens.into_iter().peekable();
 
-    let attributes = consume_attributes(&mut tokens);
+    let attributes = consume_outer_attributes(&mut tokens);
     let vis_marker = consume_vis_marker(&mut tokens);
 
     let declaration = match tokens.peek().cloned() {

--- a/src/parse_fn.rs
+++ b/src/parse_fn.rs
@@ -1,7 +1,9 @@
 use crate::parse_type::{
     consume_declaration_name, consume_field_type, consume_generic_params, consume_where_clause,
 };
-use crate::parse_utils::{consume_attributes, consume_comma, consume_stuff_until, parse_ident};
+use crate::parse_utils::{
+    consume_comma, consume_outer_attributes, consume_stuff_until, parse_ident,
+};
 use crate::punctuated::Punctuated;
 use crate::types::{
     FnParam, FnQualifiers, FnReceiverParam, FnTypedParam, Function, GroupSpan, TyExpr,
@@ -87,7 +89,7 @@ pub(crate) fn parse_fn_params(tokens: TokenStream) -> Punctuated<FnParam> {
         if tokens.peek().is_none() {
             break;
         }
-        let attributes = consume_attributes(&mut tokens);
+        let attributes = consume_outer_attributes(&mut tokens);
 
         let tk_ref = match tokens.peek() {
             Some(TokenTree::Punct(punct)) if punct.as_char() == '&' => {

--- a/src/parse_impl.rs
+++ b/src/parse_impl.rs
@@ -1,6 +1,6 @@
 use crate::parse_fn::consume_fn;
 use crate::parse_utils::{
-    consume_attributes, consume_inner_attributes, consume_stuff_until, consume_vis_marker,
+    consume_inner_attributes, consume_outer_attributes, consume_stuff_until, consume_vis_marker,
 };
 use crate::types::{Constant, ImplMember, TyDefinition, ValueExpr};
 use crate::types_edition::GroupSpan;
@@ -168,7 +168,7 @@ pub(crate) fn parse_impl_body(token_group: Group) -> (GroupSpan, Vec<Attribute>,
             break;
         }
 
-        let attributes = consume_attributes(&mut tokens);
+        let attributes = consume_outer_attributes(&mut tokens);
         let vis_marker = consume_vis_marker(&mut tokens);
         let item = consume_fn_const_or_type(&mut tokens, attributes, vis_marker, "impl");
 

--- a/src/parse_type.rs
+++ b/src/parse_type.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::parse_utils::{
-    consume_attributes, consume_colon2, consume_comma, consume_stuff_until, consume_vis_marker,
-    parse_ident,
+    consume_colon2, consume_comma, consume_outer_attributes, consume_stuff_until,
+    consume_vis_marker, parse_ident,
 };
 use crate::punctuated::Punctuated;
 use crate::types::{
@@ -349,7 +349,7 @@ pub(crate) fn parse_tuple_fields(token_group: Group) -> TupleStructFields {
             break;
         }
 
-        let attributes = consume_attributes(&mut tokens);
+        let attributes = consume_outer_attributes(&mut tokens);
         let vis_marker = consume_vis_marker(&mut tokens);
 
         let ty_tokens = consume_field_type(&mut tokens);
@@ -381,7 +381,7 @@ pub(crate) fn parse_named_fields(token_group: Group) -> NamedStructFields {
             break;
         }
 
-        let attributes = consume_attributes(&mut tokens);
+        let attributes = consume_outer_attributes(&mut tokens);
         let vis_marker = consume_vis_marker(&mut tokens);
 
         let ident = parse_ident(tokens.next().unwrap()).unwrap();
@@ -424,7 +424,7 @@ pub(crate) fn parse_enum_variants(tokens: TokenStream) -> Result<Punctuated<Enum
             break;
         }
 
-        let attributes = consume_attributes(&mut tokens);
+        let attributes = consume_outer_attributes(&mut tokens);
         let vis_marker = consume_vis_marker(&mut tokens);
 
         let ident = parse_ident(tokens.next().unwrap()).unwrap();

--- a/src/snapshots/venial__tests__parse_impl_trait.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait.snap
@@ -52,11 +52,49 @@ Impl(
                 ],
                 value: Empty,
             },
+            Attribute {
+                tk_hash: Punct {
+                    char: '#',
+                    spacing: Alone,
+                },
+                tk_bang: Punct {
+                    char: '!',
+                    spacing: Alone,
+                },
+                tk_brackets: [],
+                path: [
+                    inner2,
+                ],
+                value: Empty,
+            },
         ],
         body_items: [
             AssocTy(
                 TyDefinition {
-                    attributes: [],
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                attr,
+                            ],
+                            value: Empty,
+                        },
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                attr2,
+                            ],
+                            value: Empty,
+                        },
+                    ],
                     vis_marker: Some(
                         pub,
                     ),

--- a/src/snapshots/venial__tests__parse_impl_trait_generic.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait_generic.snap
@@ -74,7 +74,19 @@ Impl(
         body_items: [
             Constant(
                 Constant {
-                    attributes: [],
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                attr,
+                            ],
+                            value: Empty,
+                        },
+                    ],
                     vis_marker: Some(
                         pub(
                             crate,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1101,7 +1101,10 @@ fn parse_impl_trait() {
         #[outer]
         impl MyTrait for MyStruct {
             #![inner]
+            #![inner2]
 
+            #[attr]
+            #[attr2]
             pub type MyType = std::string::String;
 
             fn new(i: i32, b: bool) -> Self {
@@ -1126,6 +1129,7 @@ fn parse_impl_trait_generic() {
         where
             T: Clone,
         {
+            #[attr]
             pub(crate) const CONSTANT: i8 = N;
         }
     );


### PR DESCRIPTION
The initial implementation from #28 cannot handle this:
```rs
impl MyTrait for MyStruct {
    #![inner]
    #[outer]
    pub type MyType = std::string::String;
}
```

This pull request fixes that, by first parsing all attributes of the form `#![inner]` and then `#[outer]`.

The tests now also include such cases.