### PR TITLE
Module support

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
-use crate::parse_impl::{consume_constant, consume_fn_const_or_type, consume_for, parse_impl_body};
+use crate::parse_impl::{
+    consume_const_or_static, consume_fn_const_or_type, consume_for, parse_impl_body,
+};
 use crate::parse_type::{
     consume_declaration_name, consume_generic_params, consume_where_clause, parse_enum_variants,
     parse_named_fields, parse_tuple_fields,
@@ -269,6 +271,10 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
                 tk_braces,
             })
         }
+        Some(TokenTree::Ident(keyword)) if keyword == "static" => {
+            let static_decl = consume_const_or_static(&mut tokens, attributes, vis_marker);
+            Declaration::Constant(static_decl)
+        }
         // Note: fn qualifiers appear always in this order in Rust
         Some(TokenTree::Ident(keyword))
             if matches!(
@@ -282,7 +288,6 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
                 ImplMember::Constant(constant) => Declaration::Constant(constant),
                 ImplMember::AssocTy(ty_def) => Declaration::TyDefinition(ty_def),
             }
-
         }
         Some(token) => {
             panic!(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,7 +7,8 @@ use crate::parse_type::{
     parse_named_fields, parse_tuple_fields,
 };
 use crate::parse_utils::{
-    consume_inner_attributes, consume_outer_attributes, consume_stuff_until, consume_vis_marker,
+    consume_inner_attributes, consume_outer_attributes, consume_stuff_until,
+    consume_use_declarations, consume_vis_marker,
 };
 use crate::types::{Declaration, Enum, Impl, Mod, Struct, StructFields, Union};
 use crate::types_edition::GroupSpan;
@@ -191,6 +192,7 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
             let mut members = vec![];
             let mut tokens = stream.into_iter().peekable();
             let inner_attributes = consume_inner_attributes(&mut tokens);
+            let use_declarations = consume_use_declarations(&mut tokens);
             loop {
                 let item = parse_declaration_tokens(&mut tokens)?;
                 members.push(item);
@@ -205,7 +207,7 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
                 name: module_name,
                 tk_braces: GroupSpan::new(&group),
                 inner_attributes,
-                // FIXME use statements
+                use_declarations,
                 members,
             })
         }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -10,7 +10,7 @@ use crate::parse_utils::{
     consume_inner_attributes, consume_outer_attributes, consume_stuff_until,
     consume_use_declarations, consume_vis_marker,
 };
-use crate::types::{Declaration, Enum, Impl, Mod, Struct, StructFields, Union};
+use crate::types::{Declaration, Enum, Impl, Module, Struct, StructFields, Union};
 use crate::types_edition::GroupSpan;
 use crate::{ImplMember, TyExpr};
 use proc_macro2::token_stream::IntoIter;
@@ -177,6 +177,8 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
             })
         }
         Some(TokenTree::Ident(keyword)) if keyword == "mod" => {
+            // TODO some items currently unsupported: decl-macros, extern crate
+
             // mod keyword
             tokens.next().unwrap();
 
@@ -220,7 +222,7 @@ fn parse_declaration_tokens(mut tokens: &mut Peekable<IntoIter>) -> Result<Decla
                 members = vec![];
             }
 
-            Declaration::Mod(Mod {
+            Declaration::Module(Module {
                 attributes,
                 vis_marker,
                 tk_mod: keyword,

--- a/src/parse_impl.rs
+++ b/src/parse_impl.rs
@@ -21,7 +21,7 @@ pub(crate) fn consume_for(tokens: &mut TokenIter) -> Option<Ident> {
     }
 }
 
-pub(crate) fn consume_const_or_static(
+pub(crate) fn parse_const_or_static(
     tokens: &mut TokenIter,
     attributes: Vec<Attribute>,
     vis_marker: Option<VisMarker>,
@@ -157,7 +157,7 @@ pub(crate) fn consume_fn_const_or_type(
                 if let Some(method) = consume_fn(tokens, attributes.clone(), vis_marker.clone()) {
                     ImplMember::Method(method)
                 } else {
-                    let constant = consume_const_or_static(tokens, attributes, vis_marker);
+                    let constant = parse_const_or_static(tokens, attributes, vis_marker);
                     ImplMember::Constant(constant)
                 }
             }

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,6 +1,7 @@
 use crate::parse_type::consume_generic_args;
 use crate::types::{Attribute, AttributeValue, Path, PathSegment, VisMarker};
 use crate::types_edition::GroupSpan;
+use crate::{TyExpr, UseDeclaration};
 use proc_macro2::{Delimiter, Ident, Punct, Spacing, TokenStream, TokenTree};
 use std::iter::Peekable;
 
@@ -126,6 +127,42 @@ pub(crate) fn consume_outer_attributes(tokens: &mut TokenIter) -> Vec<Attribute>
 /// Stops _before_ encountering any outer attributes such as `#[attribute]`.
 pub(crate) fn consume_inner_attributes(tokens: &mut TokenIter) -> Vec<Attribute> {
     consume_attributes_with_inner(tokens, true)
+}
+
+pub(crate) fn consume_use_declarations(tokens: &mut TokenIter) -> Vec<UseDeclaration> {
+    let mut result = vec![];
+    loop {
+        let tk_use = match tokens.peek() {
+            Some(TokenTree::Ident(ident)) if ident == "use" => ident.clone(),
+            _ => break,
+        };
+
+        tokens.next(); // `use` keyword
+
+        let import_tree = consume_stuff_until(
+            tokens,
+            |token| match token {
+                TokenTree::Punct(punct) if punct.as_char() == ';' => true,
+                _ => false,
+            },
+            true,
+        );
+
+        let tk_semicolon = match tokens.next() {
+            Some(TokenTree::Punct(punct)) if punct.as_char() == ';' => punct.clone(),
+            _ => panic!("cannot parse use declaration: expected semicolon"),
+        };
+
+        result.push(UseDeclaration {
+            tk_use,
+            import_tree: TyExpr {
+                tokens: import_tree,
+            },
+            tk_semicolon,
+        })
+    }
+
+    result
 }
 
 pub(crate) fn consume_vis_marker(tokens: &mut TokenIter) -> Option<VisMarker> {

--- a/src/snapshots/venial__tests__parse_constant_complex.snap
+++ b/src/snapshots/venial__tests__parse_constant_complex.snap
@@ -22,9 +22,10 @@ Constant(
                 crate,
             ),
         ),
-        tk_const: Ident(
+        tk_const_or_static: Ident(
             const,
         ),
+        tk_mut: None,
         name: Ident(
             CONSTANT,
         ),

--- a/src/snapshots/venial__tests__parse_constant_expressionless.snap
+++ b/src/snapshots/venial__tests__parse_constant_expressionless.snap
@@ -6,9 +6,10 @@ Constant(
     Constant {
         attributes: [],
         vis_marker: None,
-        tk_const: Ident(
+        tk_const_or_static: Ident(
             const,
         ),
+        tk_mut: None,
         name: Ident(
             CONSTANT,
         ),

--- a/src/snapshots/venial__tests__parse_constant_simple.snap
+++ b/src/snapshots/venial__tests__parse_constant_simple.snap
@@ -6,9 +6,10 @@ Constant(
     Constant {
         attributes: [],
         vis_marker: None,
-        tk_const: Ident(
+        tk_const_or_static: Ident(
             const,
         ),
+        tk_mut: None,
         name: Ident(
             CONSTANT,
         ),

--- a/src/snapshots/venial__tests__parse_impl_inherent.snap
+++ b/src/snapshots/venial__tests__parse_impl_inherent.snap
@@ -226,9 +226,10 @@ Impl(
                     vis_marker: Some(
                         pub,
                     ),
-                    tk_const: Ident(
+                    tk_const_or_static: Ident(
                         const,
                     ),
+                    tk_mut: None,
                     name: Ident(
                         CONSTANT,
                     ),

--- a/src/snapshots/venial__tests__parse_impl_trait.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait.snap
@@ -301,9 +301,10 @@ Impl(
                 Constant {
                     attributes: [],
                     vis_marker: None,
-                    tk_const: Ident(
+                    tk_const_or_static: Ident(
                         const,
                     ),
+                    tk_mut: None,
                     name: Ident(
                         CONSTANT,
                     ),

--- a/src/snapshots/venial__tests__parse_impl_trait_generic.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait_generic.snap
@@ -92,9 +92,10 @@ Impl(
                             crate,
                         ),
                     ),
-                    tk_const: Ident(
+                    tk_const_or_static: Ident(
                         const,
                     ),
+                    tk_mut: None,
                     name: Ident(
                         CONSTANT,
                     ),

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -61,108 +61,67 @@ Module(
                 ),
             },
         ],
-        use_declarations: [
-            UseDeclaration {
-                tk_use: Ident(
-                    use,
-                ),
-                import_tree: [
-                    std,
-                    ":",
-                    ":",
-                    clone,
-                    ":",
-                    ":",
-                    Clone,
-                    as,
-                    Clown,
-                ],
-                tk_semicolon: Punct {
-                    char: ';',
-                    spacing: Alone,
-                },
-            },
-            UseDeclaration {
-                tk_use: Ident(
-                    use,
-                ),
-                import_tree: [
-                    std,
-                    ":",
-                    ":",
-                    cell,
-                    ":",
-                    ":",
-                    Group {
-                        delimiter: Brace,
-                        stream: TokenStream [
-                            Ident {
-                                sym: Cell,
-                            },
-                            Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Ident {
-                                sym: RefCell,
-                            },
-                        ],
-                    },
-                ],
-                tk_semicolon: Punct {
-                    char: ';',
-                    spacing: Alone,
-                },
-            },
-            UseDeclaration {
-                tk_use: Ident(
-                    use,
-                ),
-                import_tree: [
-                    crate,
-                    ":",
-                    ":",
-                    Group {
-                        delimiter: Brace,
-                        stream: TokenStream [
-                            Ident {
-                                sym: A,
-                            },
-                            Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Ident {
-                                sym: self,
-                            },
-                            Punct {
-                                char: ',',
-                                spacing: Alone,
-                            },
-                            Ident {
-                                sym: b,
-                            },
-                            Punct {
-                                char: ':',
-                                spacing: Joint,
-                            },
-                            Punct {
-                                char: ':',
-                                spacing: Alone,
-                            },
-                            Ident {
-                                sym: c,
-                            },
-                        ],
-                    },
-                ],
-                tk_semicolon: Punct {
-                    char: ';',
-                    spacing: Alone,
-                },
-            },
-        ],
         members: [
+            Use(
+                UseDeclaration {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_use: Ident(
+                        use,
+                    ),
+                    import_tree: [
+                        std,
+                        ":",
+                        ":",
+                        clone,
+                        ":",
+                        ":",
+                        Clone,
+                        as,
+                        Clown,
+                    ],
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
+            Use(
+                UseDeclaration {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_use: Ident(
+                        use,
+                    ),
+                    import_tree: [
+                        std,
+                        ":",
+                        ":",
+                        cell,
+                        ":",
+                        ":",
+                        Group {
+                            delimiter: Brace,
+                            stream: TokenStream [
+                                Ident {
+                                    sym: Cell,
+                                },
+                                Punct {
+                                    char: ',',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: RefCell,
+                                },
+                            ],
+                        },
+                    ],
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
             Struct(
                 Struct {
                     attributes: [],
@@ -338,6 +297,59 @@ Module(
                     ),
                 },
             ),
+            Use(
+                UseDeclaration {
+                    attributes: [],
+                    vis_marker: Some(
+                        pub,
+                    ),
+                    tk_use: Ident(
+                        use,
+                    ),
+                    import_tree: [
+                        crate,
+                        ":",
+                        ":",
+                        Group {
+                            delimiter: Brace,
+                            stream: TokenStream [
+                                Ident {
+                                    sym: A,
+                                },
+                                Punct {
+                                    char: ',',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: self,
+                                },
+                                Punct {
+                                    char: ',',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: b,
+                                },
+                                Punct {
+                                    char: ':',
+                                    spacing: Joint,
+                                },
+                                Punct {
+                                    char: ':',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: c,
+                                },
+                            ],
+                        },
+                    ],
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
             Constant(
                 Constant {
                     attributes: [],
@@ -483,7 +495,6 @@ Module(
                         {},
                     ),
                     inner_attributes: [],
-                    use_declarations: [],
                     members: [
                         Function(
                             Function {
@@ -536,7 +547,6 @@ Module(
                         {},
                     ),
                     inner_attributes: [],
-                    use_declarations: [],
                     members: [],
                 },
             ),
@@ -558,7 +568,6 @@ Module(
                     ),
                     tk_braces: None,
                     inner_attributes: [],
-                    use_declarations: [],
                     members: [],
                 },
             ),

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -2,8 +2,8 @@
 source: src/tests.rs
 expression: mod_decl
 ---
-Mod(
-    Mod {
+Module(
+    Module {
         attributes: [
             Attribute {
                 tk_hash: Punct {
@@ -468,8 +468,8 @@ Mod(
                     },
                 },
             ),
-            Mod(
-                Mod {
+            Module(
+                Module {
                     attributes: [],
                     vis_marker: None,
                     tk_mod: Ident(
@@ -521,8 +521,8 @@ Mod(
                     ],
                 },
             ),
-            Mod(
-                Mod {
+            Module(
+                Module {
                     attributes: [],
                     vis_marker: None,
                     tk_mod: Ident(
@@ -540,8 +540,8 @@ Mod(
                     members: [],
                 },
             ),
-            Mod(
-                Mod {
+            Module(
+                Module {
                     attributes: [],
                     vis_marker: None,
                     tk_mod: Ident(

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -32,7 +32,10 @@ Mod(
         name: Ident(
             one_module,
         ),
-        tk_braces: {},
+        tk_semicolon: None,
+        tk_braces: Some(
+            {},
+        ),
         inner_attributes: [
             Attribute {
                 tk_hash: Punct {
@@ -475,7 +478,10 @@ Mod(
                     name: Ident(
                         nested_mod,
                     ),
-                    tk_braces: {},
+                    tk_semicolon: None,
+                    tk_braces: Some(
+                        {},
+                    ),
                     inner_attributes: [],
                     use_declarations: [],
                     members: [
@@ -513,6 +519,47 @@ Mod(
                             },
                         ),
                     ],
+                },
+            ),
+            Mod(
+                Mod {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_mod: Ident(
+                        mod,
+                    ),
+                    name: Ident(
+                        empty_mod,
+                    ),
+                    tk_semicolon: None,
+                    tk_braces: Some(
+                        {},
+                    ),
+                    inner_attributes: [],
+                    use_declarations: [],
+                    members: [],
+                },
+            ),
+            Mod(
+                Mod {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_mod: Ident(
+                        mod,
+                    ),
+                    name: Ident(
+                        foreign_mod,
+                    ),
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                    tk_braces: None,
+                    inner_attributes: [],
+                    use_declarations: [],
+                    members: [],
                 },
             ),
         ],

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -209,6 +209,136 @@ Mod(
                     ),
                 },
             ),
+            Constant(
+                Constant {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_const_or_static: Ident(
+                        const,
+                    ),
+                    tk_mut: None,
+                    name: Ident(
+                        C,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
+                    tk_equals: Some(
+                        Punct {
+                            char: '=',
+                            spacing: Alone,
+                        },
+                    ),
+                    initializer: Some(
+                        [
+                            "-",
+                            8,
+                            "*",
+                            2,
+                        ],
+                    ),
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
+            Constant(
+                Constant {
+                    attributes: [],
+                    vis_marker: Some(
+                        pub,
+                    ),
+                    tk_const_or_static: Ident(
+                        static,
+                    ),
+                    tk_mut: None,
+                    name: Ident(
+                        MUTEX,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        std,
+                        ":",
+                        ":",
+                        sync,
+                        ":",
+                        ":",
+                        Mutex,
+                        "<",
+                        i32,
+                        ">",
+                    ],
+                    tk_equals: Some(
+                        Punct {
+                            char: '=',
+                            spacing: Alone,
+                        },
+                    ),
+                    initializer: Some(
+                        [
+                            std,
+                            ":",
+                            ":",
+                            sync,
+                            ":",
+                            ":",
+                            Mutex,
+                            ":",
+                            ":",
+                            new,
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Literal {
+                                        lit: 0,
+                                    },
+                                ],
+                            },
+                        ],
+                    ),
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
+            TyDefinition(
+                TyDefinition {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_type: Ident(
+                        type,
+                    ),
+                    name: Ident(
+                        MyType,
+                    ),
+                    tk_equals: Punct {
+                        char: '=',
+                        spacing: Alone,
+                    },
+                    initializer_ty: [
+                        Rc,
+                        "<",
+                        RefCell,
+                        "<",
+                        MyStruct,
+                        ">",
+                        ">",
+                    ],
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
             Mod(
                 Mod {
                     attributes: [],

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -33,6 +33,31 @@ Mod(
             one_module,
         ),
         tk_braces: {},
+        inner_attributes: [
+            Attribute {
+                tk_hash: Punct {
+                    char: '#',
+                    spacing: Alone,
+                },
+                tk_bang: Punct {
+                    char: '!',
+                    spacing: Alone,
+                },
+                tk_brackets: [],
+                path: [
+                    allow,
+                ],
+                value: Group(
+                    [
+                        clippy,
+                        ":",
+                        ":",
+                        iter_with_drain,
+                    ],
+                    (),
+                ),
+            },
+        ],
         members: [
             Struct(
                 Struct {
@@ -350,6 +375,7 @@ Mod(
                         nested_mod,
                     ),
                     tk_braces: {},
+                    inner_attributes: [],
                     members: [
                         Function(
                             Function {

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -58,6 +58,107 @@ Mod(
                 ),
             },
         ],
+        use_declarations: [
+            UseDeclaration {
+                tk_use: Ident(
+                    use,
+                ),
+                import_tree: [
+                    std,
+                    ":",
+                    ":",
+                    clone,
+                    ":",
+                    ":",
+                    Clone,
+                    as,
+                    Clown,
+                ],
+                tk_semicolon: Punct {
+                    char: ';',
+                    spacing: Alone,
+                },
+            },
+            UseDeclaration {
+                tk_use: Ident(
+                    use,
+                ),
+                import_tree: [
+                    std,
+                    ":",
+                    ":",
+                    cell,
+                    ":",
+                    ":",
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: Cell,
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: RefCell,
+                            },
+                        ],
+                    },
+                ],
+                tk_semicolon: Punct {
+                    char: ';',
+                    spacing: Alone,
+                },
+            },
+            UseDeclaration {
+                tk_use: Ident(
+                    use,
+                ),
+                import_tree: [
+                    crate,
+                    ":",
+                    ":",
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                sym: A,
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: self,
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: b,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: c,
+                            },
+                        ],
+                    },
+                ],
+                tk_semicolon: Punct {
+                    char: ';',
+                    spacing: Alone,
+                },
+            },
+        ],
         members: [
             Struct(
                 Struct {
@@ -376,6 +477,7 @@ Mod(
                     ),
                     tk_braces: {},
                     inner_attributes: [],
+                    use_declarations: [],
                     members: [
                         Function(
                             Function {

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -1,0 +1,262 @@
+---
+source: src/tests.rs
+expression: mod_decl
+---
+Mod(
+    Mod {
+        attributes: [
+            Attribute {
+                tk_hash: Punct {
+                    char: '#',
+                    spacing: Alone,
+                },
+                tk_brackets: [],
+                path: [
+                    path,
+                ],
+                value: Equals(
+                    [
+                        "some/module",
+                    ],
+                    Punct {
+                        char: '=',
+                        spacing: Alone,
+                    },
+                ),
+            },
+        ],
+        vis_marker: None,
+        tk_mod: Ident(
+            mod,
+        ),
+        name: Ident(
+            one_module,
+        ),
+        tk_braces: {},
+        members: [
+            Struct(
+                Struct {
+                    attributes: [],
+                    vis_marker: Some(
+                        pub,
+                    ),
+                    tk_struct: Ident(
+                        struct,
+                    ),
+                    name: Ident(
+                        MyStruct,
+                    ),
+                    generic_params: None,
+                    where_clause: None,
+                    fields: Named(
+                        [
+                            NamedField {
+                                attributes: [],
+                                vis_marker: None,
+                                name: Ident(
+                                    field,
+                                ),
+                                tk_colon: Punct {
+                                    char: ':',
+                                    spacing: Alone,
+                                },
+                                ty: [
+                                    i32,
+                                ],
+                            },
+                        ],
+                    ),
+                    tk_semicolon: None,
+                },
+            ),
+            Impl(
+                Impl {
+                    attributes: [],
+                    tk_impl: Ident(
+                        impl,
+                    ),
+                    impl_generic_params: None,
+                    trait_ty: None,
+                    tk_for: None,
+                    self_ty: [
+                        MyStruct,
+                    ],
+                    where_clause: None,
+                    tk_braces: {},
+                    inner_attributes: [],
+                    body_items: [],
+                },
+            ),
+            Impl(
+                Impl {
+                    attributes: [],
+                    tk_impl: Ident(
+                        impl,
+                    ),
+                    impl_generic_params: None,
+                    trait_ty: Some(
+                        [
+                            MyTrait,
+                        ],
+                    ),
+                    tk_for: Some(
+                        Ident(
+                            for,
+                        ),
+                    ),
+                    self_ty: [
+                        MyStruct,
+                    ],
+                    where_clause: None,
+                    tk_braces: {},
+                    inner_attributes: [],
+                    body_items: [],
+                },
+            ),
+            Enum(
+                Enum {
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                derive,
+                            ],
+                            value: Group(
+                                [
+                                    Copy,
+                                    ",",
+                                    Clone,
+                                ],
+                                (),
+                            ),
+                        },
+                    ],
+                    vis_marker: None,
+                    tk_enum: Ident(
+                        enum,
+                    ),
+                    name: Ident(
+                        Enum,
+                    ),
+                    generic_params: None,
+                    where_clauses: None,
+                    variants: [
+                        EnumVariant {
+                            attributes: [],
+                            vis_marker: None,
+                            name: Ident(
+                                Variant,
+                            ),
+                            contents: Unit,
+                            value: None,
+                        },
+                    ],
+                },
+            ),
+            Function(
+                Function {
+                    attributes: [],
+                    vis_marker: None,
+                    qualifiers: FnQualifiers {
+                        tk_default: None,
+                        tk_const: None,
+                        tk_async: None,
+                        tk_unsafe: None,
+                        tk_extern: None,
+                        extern_abi: None,
+                    },
+                    tk_fn_keyword: Ident(
+                        fn,
+                    ),
+                    name: Ident(
+                        f,
+                    ),
+                    generic_params: None,
+                    tk_params_parens: (),
+                    params: [],
+                    where_clause: None,
+                    tk_return_arrow: Some(
+                        [
+                            Punct {
+                                char: '-',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: '>',
+                                spacing: Alone,
+                            },
+                        ],
+                    ),
+                    return_ty: Some(
+                        [
+                            bool,
+                        ],
+                    ),
+                    tk_semicolon: None,
+                    body: Some(
+                        Group {
+                            delimiter: Brace,
+                            stream: TokenStream [
+                                Ident {
+                                    sym: true,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Mod(
+                Mod {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_mod: Ident(
+                        mod,
+                    ),
+                    name: Ident(
+                        nested_mod,
+                    ),
+                    tk_braces: {},
+                    members: [
+                        Function(
+                            Function {
+                                attributes: [],
+                                vis_marker: None,
+                                qualifiers: FnQualifiers {
+                                    tk_default: None,
+                                    tk_const: None,
+                                    tk_async: None,
+                                    tk_unsafe: None,
+                                    tk_extern: None,
+                                    extern_abi: None,
+                                },
+                                tk_fn_keyword: Ident(
+                                    fn,
+                                ),
+                                name: Ident(
+                                    g,
+                                ),
+                                generic_params: None,
+                                tk_params_parens: (),
+                                params: [],
+                                where_clause: None,
+                                tk_return_arrow: None,
+                                return_ty: None,
+                                tk_semicolon: None,
+                                body: Some(
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                },
+            ),
+        ],
+    },
+)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1250,6 +1250,10 @@ fn parse_mod() {
         mod one_module {
             #![allow(clippy::iter_with_drain)]
 
+            use std::clone::Clone as Clown;
+            use std::cell::{Cell, RefCell};
+            use crate::{A, self, b::c};
+
             pub struct MyStruct {
                 field: i32,
             }
@@ -1272,6 +1276,9 @@ fn parse_mod() {
             mod nested_mod {
                 fn g() {}
             }
+
+            //mod empty_mod {}
+            //mod foreign_mod;
         }
     };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1277,8 +1277,8 @@ fn parse_mod() {
                 fn g() {}
             }
 
-            //mod empty_mod {}
-            //mod foreign_mod;
+            mod empty_mod {}
+            mod foreign_mod;
         }
     };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1252,7 +1252,6 @@ fn parse_mod() {
 
             use std::clone::Clone as Clown;
             use std::cell::{Cell, RefCell};
-            use crate::{A, self, b::c};
 
             pub struct MyStruct {
                 field: i32,
@@ -1266,6 +1265,8 @@ fn parse_mod() {
             }
 
             fn f() -> bool { true }
+
+            pub use crate::{A, self, b::c};
 
             const C: i32 = -8 * 2;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1238,3 +1238,43 @@ fn interpret_ty_expr_invalid_as_path() {
     let invalid = ty_expr.as_path();
     assert!(invalid.is_none())
 }
+
+// ================
+// MOD DECLARATIONS
+// ================
+
+#[test]
+fn parse_mod() {
+    let expr = quote! {
+        #[path = "some/module"]
+        mod one_module {
+            //#![allow(clippy::iter_with_drain)]
+
+            pub struct MyStruct {
+                field: i32,
+            }
+            impl MyStruct {}
+            impl MyTrait for MyStruct {}
+
+            #[derive(Copy, Clone)]
+            enum Enum {
+                Variant,
+            }
+
+            fn f() -> bool { true }
+
+            const C: i32 = -8 * 2;
+
+            pub static MUTEX: std::sync::Mutex<i32> = std::sync::Mutex::new(0);
+
+            type MyType = Rc<RefCell<MyStruct>>;
+
+            mod nested_mod {
+                fn g() {}
+            }
+        }
+    };
+
+    let mod_decl = parse_declaration_checked(expr);
+    assert_debug_snapshot!(mod_decl);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1248,7 +1248,7 @@ fn parse_mod() {
     let expr = quote! {
         #[path = "some/module"]
         mod one_module {
-            //#![allow(clippy::iter_with_drain)]
+            #![allow(clippy::iter_with_drain)]
 
             pub struct MyStruct {
                 field: i32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -197,18 +197,26 @@ pub enum ImplMember {
     // other items like macro!{...} or macro!(...); invocations
 }
 
-/// Constant declaration.
+/// Constant or static declaration.
 ///
-/// **Example input:**
+/// **Example inputs:**
 ///
 /// ```no_run
 /// pub const CONSTANT: i32 = 783;
+/// # trait Trait {
+/// const CONSTANT: i32;
+/// # }
+/// static MUTEX: std::sync::Mutex<i32> = std::sync::Mutex::new(0);
+/// pub(crate) static mut STATIC: i32 = 7;
 /// ```
 #[derive(Clone, Debug)]
 pub struct Constant {
     pub attributes: Vec<Attribute>,
     pub vis_marker: Option<VisMarker>,
-    pub tk_const: Ident,
+    /// Either `const` or `static` keyword
+    pub tk_const_or_static: Ident,
+    /// `mut` keyword in `static mut`, absent for `const` or immutable `static`
+    pub tk_mut: Option<Ident>,
     pub name: Ident,
     pub tk_colon: Punct,
     pub ty: TyExpr,
@@ -912,7 +920,7 @@ impl ToTokens for Constant {
             attribute.to_tokens(tokens);
         }
         self.vis_marker.to_tokens(tokens);
-        self.tk_const.to_tokens(tokens);
+        self.tk_const_or_static.to_tokens(tokens);
         self.name.to_tokens(tokens);
         self.tk_colon.to_tokens(tokens);
         self.ty.to_tokens(tokens);

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,6 +30,7 @@ pub enum Declaration {
     Struct(Struct),
     Enum(Enum),
     Union(Union),
+    Mod(Mod),
     Impl(Impl),
     TyDefinition(TyDefinition),
     Function(Function),
@@ -113,6 +114,25 @@ pub struct EnumVariant {
 
     /// The value of the variant, normally for c-like enums.
     pub value: Option<EnumVariantValue>,
+}
+
+/// Declaration of a module.
+///
+/// **Example input:**
+///
+/// ```no_run
+/// mod module {
+///     // ...
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct Mod {
+    pub attributes: Vec<Attribute>,
+    pub vis_marker: Option<VisMarker>,
+    pub tk_mod: Ident,
+    pub name: Ident,
+    pub tk_braces: GroupSpan,
+    pub members: Vec<Declaration>,
 }
 
 /// Declaration of an union.
@@ -802,6 +822,7 @@ impl ToTokens for Declaration {
             Declaration::Struct(struct_decl) => struct_decl.to_tokens(tokens),
             Declaration::Enum(enum_decl) => enum_decl.to_tokens(tokens),
             Declaration::Union(union_decl) => union_decl.to_tokens(tokens),
+            Declaration::Mod(mod_decl) => mod_decl.to_tokens(tokens),
             Declaration::Impl(impl_decl) => impl_decl.to_tokens(tokens),
             Declaration::TyDefinition(ty_decl) => ty_decl.to_tokens(tokens),
             Declaration::Function(function_decl) => function_decl.to_tokens(tokens),
@@ -926,6 +947,22 @@ impl ToTokens for Union {
         self.generic_params.to_tokens(tokens);
         self.where_clause.to_tokens(tokens);
         self.fields.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Mod {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for attribute in &self.attributes {
+            attribute.to_tokens(tokens);
+        }
+        self.vis_marker.to_tokens(tokens);
+        self.tk_mod.to_tokens(tokens);
+        self.name.to_tokens(tokens);
+        self.tk_braces.quote_with(tokens, |tokens| {
+            for token in &self.members {
+                token.to_tokens(tokens);
+            }
+        });
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -132,6 +132,7 @@ pub struct Mod {
     pub tk_mod: Ident,
     pub name: Ident,
     pub tk_braces: GroupSpan,
+    pub inner_attributes: Vec<Attribute>,
     pub members: Vec<Declaration>,
 }
 
@@ -921,6 +922,7 @@ impl ToTokens for Constant {
         }
         self.vis_marker.to_tokens(tokens);
         self.tk_const_or_static.to_tokens(tokens);
+        self.tk_mut.to_tokens(tokens);
         self.name.to_tokens(tokens);
         self.tk_colon.to_tokens(tokens);
         self.ty.to_tokens(tokens);
@@ -967,6 +969,9 @@ impl ToTokens for Mod {
         self.tk_mod.to_tokens(tokens);
         self.name.to_tokens(tokens);
         self.tk_braces.quote_with(tokens, |tokens| {
+            for attribute in &self.inner_attributes {
+                attribute.to_tokens(tokens);
+            }
             for token in &self.members {
                 token.to_tokens(tokens);
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,7 +30,7 @@ pub enum Declaration {
     Struct(Struct),
     Enum(Enum),
     Union(Union),
-    Mod(Mod),
+    Module(Module),
     Impl(Impl),
     TyDefinition(TyDefinition),
     Function(Function),
@@ -126,7 +126,7 @@ pub struct EnumVariant {
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct Mod {
+pub struct Module {
     pub attributes: Vec<Attribute>,
     pub vis_marker: Option<VisMarker>,
     pub tk_mod: Ident,
@@ -855,7 +855,7 @@ impl ToTokens for Declaration {
             Declaration::Struct(struct_decl) => struct_decl.to_tokens(tokens),
             Declaration::Enum(enum_decl) => enum_decl.to_tokens(tokens),
             Declaration::Union(union_decl) => union_decl.to_tokens(tokens),
-            Declaration::Mod(mod_decl) => mod_decl.to_tokens(tokens),
+            Declaration::Module(mod_decl) => mod_decl.to_tokens(tokens),
             Declaration::Impl(impl_decl) => impl_decl.to_tokens(tokens),
             Declaration::TyDefinition(ty_decl) => ty_decl.to_tokens(tokens),
             Declaration::Function(function_decl) => function_decl.to_tokens(tokens),
@@ -984,7 +984,7 @@ impl ToTokens for Union {
     }
 }
 
-impl ToTokens for Mod {
+impl ToTokens for Module {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         for attribute in &self.attributes {
             attribute.to_tokens(tokens);

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -20,6 +20,7 @@ impl Declaration {
             Declaration::TyDefinition(ty_decl) => &ty_decl.attributes,
             Declaration::Function(function_decl) => &function_decl.attributes,
             Declaration::Constant(const_decl) => &const_decl.attributes,
+            Declaration::Use(use_decl) => &use_decl.attributes,
         }
     }
 
@@ -34,6 +35,7 @@ impl Declaration {
             Declaration::TyDefinition(ty_decl) => &mut ty_decl.attributes,
             Declaration::Function(function_decl) => &mut function_decl.attributes,
             Declaration::Constant(const_decl) => &mut const_decl.attributes,
+            Declaration::Use(use_decl) => &mut use_decl.attributes,
         }
     }
 
@@ -53,6 +55,7 @@ impl Declaration {
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_ref(),
             Declaration::Constant(_) => None,
+            Declaration::Use(_) => None,
         }
     }
 
@@ -72,6 +75,7 @@ impl Declaration {
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_mut(),
             Declaration::Constant(_) => None,
+            Declaration::Use(_) => None,
         }
     }
 
@@ -98,6 +102,7 @@ impl Declaration {
             Declaration::TyDefinition(ty_decl) => Some(ty_decl.name.clone()),
             Declaration::Function(function_decl) => Some(function_decl.name.clone()),
             Declaration::Constant(const_decl) => Some(const_decl.name.clone()),
+            Declaration::Use(_) => None,
         }
     }
 

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -4,7 +4,7 @@ pub use crate::types::{
     GenericBound, GenericParam, GenericParamList, GroupSpan, InlineGenericArgs, NamedField, Struct,
     StructFields, TupleField, TyExpr, Union, VisMarker, WhereClause, WhereClauseItem,
 };
-use crate::types::{FnQualifiers, GenericArg, GenericArgList, Impl, Path};
+use crate::types::{FnQualifiers, GenericArg, GenericArgList, Impl, Mod, Path};
 use crate::{Constant, Punctuated, TyDefinition};
 use proc_macro2::{Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
@@ -15,6 +15,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => &struct_decl.attributes,
             Declaration::Enum(enum_decl) => &enum_decl.attributes,
             Declaration::Union(union_decl) => &union_decl.attributes,
+            Declaration::Mod(mod_decl) => &mod_decl.attributes,
             Declaration::Impl(impl_decl) => &impl_decl.attributes,
             Declaration::TyDefinition(ty_decl) => &ty_decl.attributes,
             Declaration::Function(function_decl) => &function_decl.attributes,
@@ -28,6 +29,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => &mut struct_decl.attributes,
             Declaration::Enum(enum_decl) => &mut enum_decl.attributes,
             Declaration::Union(union_decl) => &mut union_decl.attributes,
+            Declaration::Mod(mod_decl) => &mut mod_decl.attributes,
             Declaration::Impl(impl_decl) => &mut impl_decl.attributes,
             Declaration::TyDefinition(ty_decl) => &mut ty_decl.attributes,
             Declaration::Function(function_decl) => &mut function_decl.attributes,
@@ -46,6 +48,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => struct_decl.generic_params.as_ref(),
             Declaration::Enum(enum_decl) => enum_decl.generic_params.as_ref(),
             Declaration::Union(union_decl) => union_decl.generic_params.as_ref(),
+            Declaration::Mod(_) => None,
             Declaration::Impl(impl_decl) => impl_decl.impl_generic_params.as_ref(),
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_ref(),
@@ -64,6 +67,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => struct_decl.generic_params.as_mut(),
             Declaration::Enum(enum_decl) => enum_decl.generic_params.as_mut(),
             Declaration::Union(union_decl) => union_decl.generic_params.as_mut(),
+            Declaration::Mod(_) => None,
             Declaration::Impl(impl_decl) => impl_decl.impl_generic_params.as_mut(),
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_mut(),
@@ -89,6 +93,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => Some(struct_decl.name.clone()),
             Declaration::Enum(enum_decl) => Some(enum_decl.name.clone()),
             Declaration::Union(union_decl) => Some(union_decl.name.clone()),
+            Declaration::Mod(mod_decl) => Some(mod_decl.name.clone()),
             Declaration::Impl(_) => None,
             Declaration::TyDefinition(ty_decl) => Some(ty_decl.name.clone()),
             Declaration::Function(function_decl) => Some(function_decl.name.clone()),
@@ -116,6 +121,14 @@ impl Declaration {
     pub fn as_union(&self) -> Option<&Union> {
         match self {
             Declaration::Union(union_decl) => Some(union_decl),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`Mod`] variant of the enum if possible.
+    pub fn as_mod(&self) -> Option<&Mod> {
+        match self {
+            Declaration::Mod(mod_decl) => Some(mod_decl),
             _ => None,
         }
     }

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -4,7 +4,7 @@ pub use crate::types::{
     GenericBound, GenericParam, GenericParamList, GroupSpan, InlineGenericArgs, NamedField, Struct,
     StructFields, TupleField, TyExpr, Union, VisMarker, WhereClause, WhereClauseItem,
 };
-use crate::types::{FnQualifiers, GenericArg, GenericArgList, Impl, Mod, Path};
+use crate::types::{FnQualifiers, GenericArg, GenericArgList, Impl, Module, Path};
 use crate::{Constant, Punctuated, TyDefinition};
 use proc_macro2::{Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 
@@ -15,7 +15,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => &struct_decl.attributes,
             Declaration::Enum(enum_decl) => &enum_decl.attributes,
             Declaration::Union(union_decl) => &union_decl.attributes,
-            Declaration::Mod(mod_decl) => &mod_decl.attributes,
+            Declaration::Module(mod_decl) => &mod_decl.attributes,
             Declaration::Impl(impl_decl) => &impl_decl.attributes,
             Declaration::TyDefinition(ty_decl) => &ty_decl.attributes,
             Declaration::Function(function_decl) => &function_decl.attributes,
@@ -29,7 +29,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => &mut struct_decl.attributes,
             Declaration::Enum(enum_decl) => &mut enum_decl.attributes,
             Declaration::Union(union_decl) => &mut union_decl.attributes,
-            Declaration::Mod(mod_decl) => &mut mod_decl.attributes,
+            Declaration::Module(mod_decl) => &mut mod_decl.attributes,
             Declaration::Impl(impl_decl) => &mut impl_decl.attributes,
             Declaration::TyDefinition(ty_decl) => &mut ty_decl.attributes,
             Declaration::Function(function_decl) => &mut function_decl.attributes,
@@ -48,7 +48,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => struct_decl.generic_params.as_ref(),
             Declaration::Enum(enum_decl) => enum_decl.generic_params.as_ref(),
             Declaration::Union(union_decl) => union_decl.generic_params.as_ref(),
-            Declaration::Mod(_) => None,
+            Declaration::Module(_) => None,
             Declaration::Impl(impl_decl) => impl_decl.impl_generic_params.as_ref(),
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_ref(),
@@ -67,7 +67,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => struct_decl.generic_params.as_mut(),
             Declaration::Enum(enum_decl) => enum_decl.generic_params.as_mut(),
             Declaration::Union(union_decl) => union_decl.generic_params.as_mut(),
-            Declaration::Mod(_) => None,
+            Declaration::Module(_) => None,
             Declaration::Impl(impl_decl) => impl_decl.impl_generic_params.as_mut(),
             Declaration::TyDefinition(_) => None,
             Declaration::Function(function_decl) => function_decl.generic_params.as_mut(),
@@ -93,7 +93,7 @@ impl Declaration {
             Declaration::Struct(struct_decl) => Some(struct_decl.name.clone()),
             Declaration::Enum(enum_decl) => Some(enum_decl.name.clone()),
             Declaration::Union(union_decl) => Some(union_decl.name.clone()),
-            Declaration::Mod(mod_decl) => Some(mod_decl.name.clone()),
+            Declaration::Module(mod_decl) => Some(mod_decl.name.clone()),
             Declaration::Impl(_) => None,
             Declaration::TyDefinition(ty_decl) => Some(ty_decl.name.clone()),
             Declaration::Function(function_decl) => Some(function_decl.name.clone()),
@@ -126,9 +126,9 @@ impl Declaration {
     }
 
     /// Returns the [`Mod`] variant of the enum if possible.
-    pub fn as_mod(&self) -> Option<&Mod> {
+    pub fn as_module(&self) -> Option<&Module> {
         match self {
-            Declaration::Mod(mod_decl) => Some(mod_decl),
+            Declaration::Module(mod_decl) => Some(mod_decl),
             _ => None,
         }
     }


### PR DESCRIPTION
Adds support for `mod` and `static`.

Modules currently can contain these item types (which can now be top-level `Declaration` as well):
* `const`
* `static` (new)
* `fn`
* `struct`
* `enum`
* `union`
* `impl`

These item types can be inside `mod`, but are not parsed as top-level `Declaration`s themselves:
* `#![inner]` attributes
* `use` statements

Not supported:
* Declarative macros
* Traits (will follow in a later PR)
* `extern crate`
* possibly some other token combinations I forgot