### PR TITLE
Simplify often-used ident/punct parsers

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,9 +4,7 @@ use crate::parse_type::{
     consume_declaration_name, consume_generic_params, consume_where_clause, parse_enum_variants,
     parse_named_fields, parse_tuple_fields,
 };
-use crate::parse_utils::{
-    consume_inner_attributes, consume_outer_attributes, consume_vis_marker, parse_use_declarations,
-};
+use crate::parse_utils::{consume_inner_attributes, consume_outer_attributes, consume_punct, consume_vis_marker, parse_use_declarations};
 use crate::types::{Declaration, Enum, Module, Struct, StructFields, Union};
 use crate::types_edition::GroupSpan;
 use proc_macro2::token_stream::IntoIter;
@@ -100,14 +98,7 @@ fn parse_declaration_tokens(tokens: &mut Peekable<IntoIter>) -> Result<Declarati
                 where_clause = consume_where_clause(tokens);
             }
 
-            let semicolon = match tokens.peek() {
-                Some(TokenTree::Punct(punct)) if punct.as_char() == ';' => {
-                    let punct = punct.clone();
-                    tokens.next().unwrap();
-                    Some(punct)
-                }
-                _ => None,
-            };
+            let semicolon = consume_punct(tokens, ';');
 
             Declaration::Struct(Struct {
                 attributes,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,7 +4,10 @@ use crate::parse_type::{
     consume_declaration_name, consume_generic_params, consume_where_clause, parse_enum_variants,
     parse_named_fields, parse_tuple_fields,
 };
-use crate::parse_utils::{consume_inner_attributes, consume_outer_attributes, consume_punct, consume_vis_marker, parse_use_declarations};
+use crate::parse_utils::{
+    consume_inner_attributes, consume_outer_attributes, consume_punct, consume_vis_marker,
+    parse_use_declarations,
+};
 use crate::types::{Declaration, Enum, Module, Struct, StructFields, Union};
 use crate::types_edition::GroupSpan;
 use proc_macro2::token_stream::IntoIter;

--- a/src/parse_fn.rs
+++ b/src/parse_fn.rs
@@ -99,11 +99,7 @@ pub(crate) fn parse_fn_params(tokens: TokenStream) -> Punctuated<FnParam> {
 }
 
 pub(crate) fn consume_fn_return(tokens: &mut TokenIter) -> Option<([Punct; 2], TyExpr)> {
-    let dash = if let Some(token) = consume_punct(tokens, '-') {
-        token
-    } else {
-        return None;
-    };
+    let dash = consume_punct(tokens, '-')?;
 
     let tip = match tokens.next() {
         Some(TokenTree::Punct(punct)) if punct.as_char() == '>' => punct,

--- a/src/parse_type.rs
+++ b/src/parse_type.rs
@@ -23,11 +23,7 @@ pub(crate) fn consume_declaration_name(tokens: &mut TokenIter) -> Ident {
 pub(crate) fn consume_generic_params(tokens: &mut TokenIter) -> Option<GenericParamList> {
     let mut generic_params = Punctuated::new();
 
-    let gt = if let Some(token) = consume_punct(tokens, '<') {
-        token
-    } else {
-        return None;
-    };
+    let gt = consume_punct(tokens, '<')?;
 
     let lt: Punct;
     loop {
@@ -203,11 +199,7 @@ pub(crate) fn consume_generic_args(tokens: &mut TokenIter) -> Option<GenericArgL
 }
 
 pub(crate) fn consume_where_clause(tokens: &mut TokenIter) -> Option<WhereClause> {
-    let where_token = if let Some(token) = consume_ident(tokens, "where") {
-        token
-    } else {
-        return None;
-    };
+    let where_token = consume_ident(tokens, "where")?;
 
     let mut items = Punctuated::new();
     loop {

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -572,27 +572,23 @@ impl GenericParam {
 
     /// Returns true if the generic param is a lifetime param.
     pub fn is_lifetime(&self) -> bool {
-        match &self.tk_prefix {
-            Some(TokenTree::Punct(punct)) if punct.as_char() == '\'' => true,
-            _ => false,
-        }
+        matches!(
+            &self.tk_prefix,
+            Some(TokenTree::Punct(punct)) if punct.as_char() == '\''
+        )
     }
 
     /// Returns true if the generic param is a type param.
     pub fn is_ty(&self) -> bool {
-        #[allow(clippy::redundant_pattern_matching)]
-        match &self.tk_prefix {
-            Some(_) => false,
-            None => true,
-        }
+        self.tk_prefix.is_none()
     }
 
     /// Returns true if the generic param is a const param.
     pub fn is_const(&self) -> bool {
-        match &self.tk_prefix {
-            Some(TokenTree::Ident(ident)) if ident == "const" => true,
-            _ => false,
-        }
+        matches!(
+            &self.tk_prefix,
+            Some(TokenTree::Ident(ident)) if ident == "const"
+        )
     }
 }
 


### PR DESCRIPTION
Builds on top of #33, which should be merged first

Relevant diff: [here](https://github.com/PoignardAzur/venial/pull/34/files/8f3644da954bebee5405bda1713b945299795b7f..7393f4f38b8ff674901c01a78e775c3569b3464c)
~~Relevant diff: [`c4499e9..397ed81`](https://github.com/PoignardAzur/venial/pull/34/files/c4499e98e7b683e451b3a14e945ffd5591a9826e..397ed8114086b2fe1412824f6c5d37c7b59e8600)~~