### PR TITLE
Reject trailing tokens after declaration

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -60,7 +60,14 @@ use std::iter::Peekable;
 
 pub fn parse_declaration(tokens: TokenStream) -> Result<Declaration, Error> {
     let mut tokens = tokens.into_iter().peekable();
-    parse_declaration_tokens(&mut tokens)
+    let declaration = parse_declaration_tokens(&mut tokens);
+    if tokens.peek().is_some() {
+        panic!(
+            "cannot parse declaration, unexpected trailing tokens: {}",
+            tokens.collect::<TokenStream>()
+        );
+    }
+    declaration
 }
 
 pub(crate) fn parse_declaration_tokens(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,6 +122,17 @@ fn parse_empty_enum() {
     assert_debug_snapshot!(enum_type);
 }
 
+#[test]
+#[should_panic]
+fn reject_trailing_tokens() {
+    let declaration = parse_declaration_checked(quote::quote! {
+        struct Good {}
+        trailing junk
+    });
+
+    println!("This should have panicked: {:#?}", declaration);
+}
+
 // ==========
 // VISIBILITY
 // ==========


### PR DESCRIPTION
Current venial parses `struct Good {} bad` and silently ignores `bad` or any other trailing junk tokens. I'm not sure what the best way to deal with that is, but I think that should be an error.

(Origin issue: https://github.com/jcaesar/structstruck/issues/4)