### PR TITLE
Make parse_declaration panic if given leftover tokens.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,6 @@ mod types;
 mod types_edition;
 
 pub use error::Error;
-pub use parse::parse_declaration;
+pub use parse::{consume_declaration, parse_declaration};
 pub use punctuated::Punctuated;
 pub use types::*;

--- a/src/parse_mod.rs
+++ b/src/parse_mod.rs
@@ -1,4 +1,4 @@
-use crate::parse::parse_declaration_tokens;
+use crate::parse::consume_declaration;
 use crate::parse_type::consume_declaration_name;
 use crate::parse_utils::{
     consume_ident, consume_inner_attributes, consume_stuff_until, parse_ident, parse_punct,
@@ -43,7 +43,7 @@ pub(crate) fn parse_mod(
             if tokens.peek().is_none() {
                 break;
             }
-            let item = parse_declaration_tokens(&mut tokens)
+            let item = consume_declaration(&mut tokens)
                 .unwrap_or_else(|e| panic!("declaration in mod: {}", e));
             mod_members.push(item);
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -122,6 +122,17 @@ fn parse_empty_enum() {
     assert_debug_snapshot!(enum_type);
 }
 
+#[test]
+#[should_panic = "unexpected trailing tokens after declaration"]
+fn reject_trailing_tokens() {
+    let declaration = parse_declaration_checked(quote::quote! {
+        struct Good {}
+        trailing junk
+    });
+
+    println!("This should have panicked: {:#?}", declaration);
+}
+
 // ==========
 // VISIBILITY
 // ==========


### PR DESCRIPTION
Export consume_declaration.
Add unit test.