### PR TITLE
Macro invocations + `macro_rules!`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::parse_fn::consume_macro;
 use crate::parse_impl::{
     consume_either_fn_type_const_static_impl, parse_const_or_static, parse_impl, parse_trait,
 };
@@ -218,13 +219,17 @@ pub fn consume_declaration(tokens: &mut Peekable<IntoIter>) -> Result<Declaratio
             consume_either_fn_type_const_static_impl(tokens, attributes, vis_marker, "declaration")
         }
         Some(token) => {
-            panic!(
-                "cannot parse declaration: expected keyword struct/enum/union/type/trait/impl/mod/default/const/async/unsafe/extern/fn/static, found token {:?}",
-                token
-            );
+            if let Some(macro_) = consume_macro(tokens, attributes) {
+                Declaration::Macro(macro_)
+            } else {
+                panic!(
+                    "cannot parse declaration: expected keyword struct/enum/union/type/trait/impl/mod/default/const/async/unsafe/extern/fn/static or macro, found token {:?}",
+                    token
+                );
+            }
         }
         None => {
-            panic!("cannot parse type: expected keyword struct/enum/union/type/trait/impl/mod/default/const/async/unsafe/extern/fn/static, found end-of-stream");
+            panic!("cannot parse type: expected keyword struct/enum/union/type/trait/impl/mod/default/const/async/unsafe/extern/fn/static or macro, found end-of-stream");
         }
     };
     Ok(declaration)

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -33,6 +33,17 @@ pub(crate) fn parse_ident(tokens: &mut TokenIter, expected: &str, panic_context:
     }
 }
 
+pub(crate) fn consume_any_ident(tokens: &mut TokenIter) -> Option<Ident> {
+    match tokens.peek() {
+        Some(TokenTree::Ident(ident)) => {
+            let ident = ident.clone();
+            tokens.next();
+            Some(ident)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) fn consume_ident(tokens: &mut TokenIter, expected: &str) -> Option<Ident> {
     match tokens.peek() {
         Some(TokenTree::Ident(ident)) if ident == expected => {

--- a/src/snapshots/venial__tests__parse_impl_inherent.snap
+++ b/src/snapshots/venial__tests__parse_impl_inherent.snap
@@ -260,6 +260,93 @@ Impl(
                     },
                 },
             ),
+            Macro(
+                Macro {
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                clippy,
+                                ":",
+                                ":",
+                                allow,
+                            ],
+                            value: Group(
+                                [
+                                    venial,
+                                ],
+                                (),
+                            ),
+                        },
+                    ],
+                    name: Ident(
+                        fn_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: (),
+                    inner_tokens: [
+                        Ident {
+                            sym: MyTrait,
+                        },
+                    ],
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                },
+            ),
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        block_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: {},
+                    inner_tokens: [
+                        Ident {
+                            sym: fn,
+                        },
+                        Ident {
+                            sym: inner_fn,
+                        },
+                        Group {
+                            delimiter: Parenthesis,
+                            stream: TokenStream [],
+                        },
+                        Punct {
+                            char: '-',
+                            spacing: Joint,
+                        },
+                        Punct {
+                            char: '>',
+                            spacing: Alone,
+                        },
+                        Ident {
+                            sym: bool,
+                        },
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ],
+                    tk_semicolon: None,
+                },
+            ),
         ],
     },
 )

--- a/src/snapshots/venial__tests__parse_impl_trait.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait.snap
@@ -340,6 +340,93 @@ Impl(
                     },
                 },
             ),
+            Macro(
+                Macro {
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                clippy,
+                                ":",
+                                ":",
+                                allow,
+                            ],
+                            value: Group(
+                                [
+                                    venial,
+                                ],
+                                (),
+                            ),
+                        },
+                    ],
+                    name: Ident(
+                        fn_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: (),
+                    inner_tokens: [
+                        Ident {
+                            sym: MyTrait,
+                        },
+                    ],
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                },
+            ),
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        block_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: {},
+                    inner_tokens: [
+                        Ident {
+                            sym: fn,
+                        },
+                        Ident {
+                            sym: inner_fn,
+                        },
+                        Group {
+                            delimiter: Parenthesis,
+                            stream: TokenStream [],
+                        },
+                        Punct {
+                            char: '-',
+                            spacing: Joint,
+                        },
+                        Punct {
+                            char: '>',
+                            spacing: Alone,
+                        },
+                        Ident {
+                            sym: bool,
+                        },
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ],
+                    tk_semicolon: None,
+                },
+            ),
         ],
     },
 )

--- a/src/snapshots/venial__tests__parse_mod.snap
+++ b/src/snapshots/venial__tests__parse_mod.snap
@@ -621,6 +621,158 @@ Module(
                     members: [],
                 },
             ),
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        decl_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: (),
+                    inner_tokens: [
+                        Ident {
+                            sym: args,
+                        },
+                        Punct {
+                            char: ',',
+                            spacing: Alone,
+                        },
+                        Literal {
+                            lit: 32,
+                        },
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                        Punct {
+                            char: '+',
+                            spacing: Alone,
+                        },
+                        Punct {
+                            char: '*',
+                            spacing: Alone,
+                        },
+                    ],
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                },
+            ),
+            Macro(
+                Macro {
+                    attributes: [
+                        Attribute {
+                            tk_hash: Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            tk_brackets: [],
+                            path: [
+                                macro_export,
+                            ],
+                            value: Empty,
+                        },
+                    ],
+                    name: Ident(
+                        macro_rules,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: Some(
+                        Ident(
+                            stringificate,
+                        ),
+                    ),
+                    tk_braces_or_parens: {},
+                    inner_tokens: [
+                        Group {
+                            delimiter: Parenthesis,
+                            stream: TokenStream [],
+                        },
+                        Punct {
+                            char: '=',
+                            spacing: Joint,
+                        },
+                        Punct {
+                            char: '>',
+                            spacing: Alone,
+                        },
+                        Group {
+                            delimiter: Brace,
+                            stream: TokenStream [
+                                Literal {
+                                    lit: "<None>",
+                                },
+                            ],
+                        },
+                        Group {
+                            delimiter: Parenthesis,
+                            stream: TokenStream [
+                                Punct {
+                                    char: '$',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: item,
+                                },
+                                Punct {
+                                    char: ':',
+                                    spacing: Alone,
+                                },
+                                Ident {
+                                    sym: item,
+                                },
+                            ],
+                        },
+                        Punct {
+                            char: '=',
+                            spacing: Joint,
+                        },
+                        Punct {
+                            char: '>',
+                            spacing: Alone,
+                        },
+                        Group {
+                            delimiter: Brace,
+                            stream: TokenStream [
+                                Ident {
+                                    sym: stringify,
+                                },
+                                Punct {
+                                    char: '!',
+                                    spacing: Alone,
+                                },
+                                Group {
+                                    delimiter: Parenthesis,
+                                    stream: TokenStream [
+                                        Punct {
+                                            char: '$',
+                                            spacing: Alone,
+                                        },
+                                        Ident {
+                                            sym: item,
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ],
+                    tk_semicolon: None,
+                },
+            ),
         ],
     },
 )

--- a/src/snapshots/venial__tests__parse_trait_simple.snap
+++ b/src/snapshots/venial__tests__parse_trait_simple.snap
@@ -275,6 +275,80 @@ Trait(
                     },
                 },
             ),
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        decl_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: (),
+                    inner_tokens: [],
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                },
+            ),
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        python,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: {},
+                    inner_tokens: [
+                        Ident {
+                            sym: def,
+                        },
+                        Ident {
+                            sym: hello,
+                        },
+                        Group {
+                            delimiter: Parenthesis,
+                            stream: TokenStream [
+                                Ident {
+                                    sym: b,
+                                },
+                            ],
+                        },
+                        Punct {
+                            char: ':',
+                            spacing: Alone,
+                        },
+                        Ident {
+                            sym: return,
+                        },
+                        Literal {
+                            lit: "hello world",
+                        },
+                        Ident {
+                            sym: if,
+                        },
+                        Ident {
+                            sym: b,
+                        },
+                        Ident {
+                            sym: else,
+                        },
+                        Literal {
+                            lit: "bye world",
+                        },
+                    ],
+                    tk_semicolon: None,
+                },
+            ),
         ],
     },
 )

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -595,6 +595,20 @@ fn parse_complex_enum_variant() {
     assert_debug_snapshot!(enum_type_3);
 }
 
+#[test]
+#[should_panic] // FIXME
+fn parse_enum_with_macro() {
+    let enum_decl = parse_declaration(quote!(
+        enum Hello {
+            A = 1,
+            macroified! { B = 2 },
+            macroified!(B; 2),
+        }
+    ));
+
+    assert_debug_snapshot!(enum_decl);
+}
+
 // =================
 // TYPE CORNER CASES
 // =================
@@ -930,6 +944,22 @@ fn parse_struct_declaration(tokens: TokenStream) -> Struct {
 }
 
 #[test]
+#[should_panic] // FIXME
+fn parse_struct_with_macro() {
+    let struct_decl = parse_struct_declaration(quote!(
+        struct Hello {
+            a: A,
+            b: B,
+            transmogrify! {
+                c: C,
+            }
+        }
+    ));
+
+    assert_quote_snapshot!(struct_decl);
+}
+
+#[test]
 fn add_lifetime() {
     let basic_type = parse_struct_declaration(quote!(
         struct Hello {
@@ -1089,6 +1119,13 @@ fn parse_impl_inherent() {
             pub(crate) fn set_value(&mut self, s: String) {}
 
             pub const CONSTANT: i8 = 24 + 7;
+
+            #[clippy::allow(venial)]
+            fn_macro!(MyTrait);
+
+            block_macro! {
+                fn inner_fn() -> bool;
+            }
         }
     );
 
@@ -1126,6 +1163,13 @@ fn parse_impl_trait() {
             const fn set_value(&mut self, s: String) {}
 
             const CONSTANT: i8 = 24 + 7;
+
+            #[clippy::allow(venial)]
+            fn_macro!(MyTrait);
+
+            block_macro! {
+                fn inner_fn() -> bool;
+            }
         }
     );
 
@@ -1294,6 +1338,16 @@ fn parse_mod() {
 
             #[contain_it]
             unsafe mod hazard_mod {}
+
+            decl_macro!(args, 32; + *);
+
+            #[macro_export]
+            macro_rules! stringificate {
+                () => { "<None>" }
+                ($item:item) => {
+                    stringify!($item)
+                };
+            }
         }
     };
 
@@ -1319,6 +1373,13 @@ fn parse_trait_simple() {
 
             type AssocType: Bound;
             type TypeWithDefault = Rc<RefCell<MyStruct>>;
+
+            decl_macro!();
+
+            python! {
+                def hello(b):
+                    return "hello world" if b else "bye world"
+            }
         }
     };
 

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -25,6 +25,7 @@ impl Declaration {
             Declaration::Function(function_decl) => &function_decl.attributes,
             Declaration::Constant(const_decl) => &const_decl.attributes,
             Declaration::Use(use_decl) => &use_decl.attributes,
+            Declaration::Macro(macro_decl) => &macro_decl.attributes,
         }
     }
 
@@ -43,6 +44,7 @@ impl Declaration {
             Declaration::Function(function_decl) => &mut function_decl.attributes,
             Declaration::Constant(const_decl) => &mut const_decl.attributes,
             Declaration::Use(use_decl) => &mut use_decl.attributes,
+            Declaration::Macro(macro_decl) => &mut macro_decl.attributes,
         }
     }
 
@@ -66,6 +68,7 @@ impl Declaration {
             Declaration::Function(function_decl) => function_decl.generic_params.as_ref(),
             Declaration::Constant(_) => None,
             Declaration::Use(_) => None,
+            Declaration::Macro(_) => None,
         }
     }
 
@@ -89,6 +92,7 @@ impl Declaration {
             Declaration::Function(function_decl) => function_decl.generic_params.as_mut(),
             Declaration::Constant(_) => None,
             Declaration::Use(_) => None,
+            Declaration::Macro(_) => None,
         }
     }
 
@@ -117,6 +121,7 @@ impl Declaration {
             Declaration::Function(function_decl) => Some(function_decl.name.clone()),
             Declaration::Constant(const_decl) => Some(const_decl.name.clone()),
             Declaration::Use(_) => None,
+            Declaration::Macro(macro_) => Some(macro_.name.clone()),
         }
     }
 


### PR DESCRIPTION
Initial support for declarative/function-style procedural macro invocations, as well as `macro_rules!` declarations.

```rs
fn_macro!(args);

block_macro! {
    fn inner_fn() -> bool;
}

#[macro_export]
macro_rules! stringificate {
    ($item:item) => {
        stringify!($item)
    };
}
```

Currently limited to `mod`/`impl`/`trait` blocks.

Later I'd like to add support for `struct`, `enum` and `union`, so that a macro can appear in place of a struct field or enum/union variant (e.g. between commas).

I do _not_ plan to support all possible positions where macros are syntactically allowed in Rust (e.g. where clauses), as that would significantly increase the complexity of the parser, for relatively little benefit in everyday life. The above-mentioned items on the other hand are rather common candidates for macros.