### PR TITLE
Support `extern {}` and `extern crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod tests;
 
 mod error;
 mod parse;
+mod parse_extern;
 mod parse_fn;
 mod parse_impl;
 mod parse_mod;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -202,13 +202,12 @@ pub fn consume_declaration(tokens: &mut Peekable<IntoIter>) -> Result<Declaratio
             let static_decl = parse_const_or_static(tokens, attributes, vis_marker);
             Declaration::Constant(static_decl)
         }
-        // Note: fn qualifiers appear always in this order in Rust: default const async unsafe extern fn
         Some(TokenTree::Ident(keyword)) if keyword == "use" => {
             let use_decl = parse_use_declaration(tokens, attributes, vis_marker);
 
             Declaration::Use(use_decl)
         }
-        // Note: fn qualifiers appear always in this order in Rust
+        // Note: fn qualifiers appear always in this order in Rust: default const async unsafe extern fn
         Some(TokenTree::Ident(keyword))
             if matches!(
                 keyword.to_string().as_str(),
@@ -216,7 +215,12 @@ pub fn consume_declaration(tokens: &mut Peekable<IntoIter>) -> Result<Declaratio
             ) =>
         {
             // Reuse impl parsing
-            consume_either_fn_type_const_static_impl(tokens, attributes, vis_marker, "declaration")
+            consume_either_fn_type_const_static_impl(
+                tokens,
+                attributes,
+                vis_marker,
+                "fn/type/const/static/extern/extern crate",
+            )
         }
         Some(token) => {
             if let Some(macro_) = consume_macro(tokens, attributes) {

--- a/src/parse_extern.rs
+++ b/src/parse_extern.rs
@@ -1,0 +1,99 @@
+use crate::parse_impl::parse_impl_body;
+use crate::parse_utils::{consume_ident, parse_any_ident, parse_ident, parse_punct, TokenIter};
+use crate::{Attribute, ExternBlock, ExternCrate, VisMarker};
+use proc_macro2::{Delimiter, TokenTree};
+
+pub(crate) fn parse_extern_crate(
+    tokens: &mut TokenIter,
+    attributes: Vec<Attribute>,
+    vis_marker: Option<VisMarker>,
+) -> ExternCrate {
+    consume_extern_crate(tokens, attributes, vis_marker).expect("cannot parse extern crate")
+}
+
+fn consume_extern_crate(
+    tokens: &mut TokenIter,
+    attributes: Vec<Attribute>,
+    vis_marker: Option<VisMarker>,
+) -> Option<ExternCrate> {
+    let tk_extern = consume_ident(tokens, "extern")?;
+    let tk_crate = consume_ident(tokens, "crate")?;
+
+    let name = parse_any_ident(tokens, "extern crate");
+    let tk_as = consume_ident(tokens, "as");
+
+    let alias;
+    let tk_underscore;
+    if tk_as.is_some() {
+        alias = Some(parse_any_ident(tokens, "extern crate: alias"));
+        if alias.is_none() {
+            tk_underscore = Some(parse_ident(tokens, "_", "extern crate"));
+        } else {
+            tk_underscore = None;
+        }
+    } else {
+        alias = None;
+        tk_underscore = None;
+    }
+
+    let tk_semicolon = parse_punct(tokens, ';', "extern crate");
+
+    Some(ExternCrate {
+        attributes,
+        vis_marker,
+        tk_extern,
+        tk_crate,
+        name,
+        tk_as,
+        alias,
+        tk_underscore,
+        tk_semicolon,
+    })
+}
+
+pub(crate) fn parse_extern_block(
+    tokens: &mut TokenIter,
+    attributes: Vec<Attribute>,
+    vis_marker: Option<VisMarker>,
+) -> ExternBlock {
+    consume_extern_block(tokens, attributes, vis_marker).expect("cannot parse extern block")
+}
+
+fn consume_extern_block(
+    tokens: &mut TokenIter,
+    attributes: Vec<Attribute>,
+    vis_marker: Option<VisMarker>,
+) -> Option<ExternBlock> {
+    let tk_unsafe = consume_ident(tokens, "unsafe");
+    let tk_extern = consume_ident(tokens, "extern")?;
+
+    let extern_abi = match tokens.peek() {
+        Some(TokenTree::Literal(lit)) => {
+            let lit = Some(lit.clone());
+            tokens.next();
+            lit
+        }
+        _ => None,
+    };
+
+    let (tk_braces, inner_attributes, body_items) = match tokens.next() {
+        Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Brace => {
+            parse_impl_body(group, true)
+        }
+        _ => {
+            // Only here we know that it's not an extern crate or extern block, so try other options on call-site (fn).
+            return None;
+        }
+    };
+
+    Some(ExternBlock {
+        attributes,
+        vis_marker,
+        tk_unsafe,
+        tk_extern,
+        extern_abi,
+        tk_braces,
+        inner_attributes,
+        body_items,
+    })
+}

--- a/src/parse_mod.rs
+++ b/src/parse_mod.rs
@@ -14,8 +14,6 @@ pub(crate) fn parse_mod(
     attributes: Vec<Attribute>,
     vis_marker: Option<VisMarker>,
 ) -> Module {
-    // TODO some items currently unsupported: decl-macros, extern crate
-
     let tk_unsafe = consume_ident(tokens, "unsafe");
     let tk_mod = parse_ident(tokens, "mod", "module declaration");
     let module_name = consume_declaration_name(tokens);

--- a/src/snapshots/venial__tests__parse_extern_block-2.snap
+++ b/src/snapshots/venial__tests__parse_extern_block-2.snap
@@ -1,0 +1,22 @@
+---
+source: src/tests.rs
+expression: unsafe_extern
+---
+ExternBlock(
+    ExternBlock {
+        attributes: [],
+        vis_marker: None,
+        tk_unsafe: Some(
+            Ident(
+                unsafe,
+            ),
+        ),
+        tk_extern: Ident(
+            extern,
+        ),
+        extern_abi: None,
+        tk_braces: {},
+        inner_attributes: [],
+        body_items: [],
+    },
+)

--- a/src/snapshots/venial__tests__parse_extern_block.snap
+++ b/src/snapshots/venial__tests__parse_extern_block.snap
@@ -1,0 +1,140 @@
+---
+source: src/tests.rs
+expression: filled_extern
+---
+ExternBlock(
+    ExternBlock {
+        attributes: [
+            Attribute {
+                tk_hash: Punct {
+                    char: '#',
+                    spacing: Alone,
+                },
+                tk_brackets: [],
+                path: [
+                    decorated,
+                ],
+                value: Empty,
+            },
+        ],
+        vis_marker: Some(
+            pub(
+                crate,
+            ),
+        ),
+        tk_unsafe: None,
+        tk_extern: Ident(
+            extern,
+        ),
+        extern_abi: Some(
+            Literal {
+                lit: "stdcall",
+            },
+        ),
+        tk_braces: {},
+        inner_attributes: [
+            Attribute {
+                tk_hash: Punct {
+                    char: '#',
+                    spacing: Alone,
+                },
+                tk_bang: Punct {
+                    char: '!',
+                    spacing: Alone,
+                },
+                tk_brackets: [],
+                path: [
+                    allow,
+                ],
+                value: Group(
+                    [
+                        unused_variables,
+                    ],
+                    (),
+                ),
+            },
+        ],
+        body_items: [
+            Macro(
+                Macro {
+                    attributes: [],
+                    name: Ident(
+                        some_macro,
+                    ),
+                    tk_bang: Punct {
+                        char: '!',
+                        spacing: Alone,
+                    },
+                    tk_declared_name: None,
+                    tk_braces_or_parens: (),
+                    inner_tokens: [],
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                },
+            ),
+            Method(
+                Function {
+                    attributes: [],
+                    vis_marker: None,
+                    qualifiers: FnQualifiers {
+                        tk_default: None,
+                        tk_const: None,
+                        tk_async: None,
+                        tk_unsafe: None,
+                        tk_extern: None,
+                        extern_abi: None,
+                    },
+                    tk_fn_keyword: Ident(
+                        fn,
+                    ),
+                    name: Ident(
+                        c_function,
+                    ),
+                    generic_params: None,
+                    tk_params_parens: (),
+                    params: [],
+                    where_clause: None,
+                    tk_return_arrow: None,
+                    return_ty: None,
+                    tk_semicolon: Some(
+                        Punct {
+                            char: ';',
+                            spacing: Alone,
+                        },
+                    ),
+                    body: None,
+                },
+            ),
+            Constant(
+                Constant {
+                    attributes: [],
+                    vis_marker: None,
+                    tk_const_or_static: Ident(
+                        static,
+                    ),
+                    tk_mut: None,
+                    name: Ident(
+                        S,
+                    ),
+                    tk_colon: Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    ty: [
+                        i32,
+                    ],
+                    tk_equals: None,
+                    initializer: None,
+                    tk_semicolon: Punct {
+                        char: ';',
+                        spacing: Alone,
+                    },
+                },
+            ),
+        ],
+    },
+)

--- a/src/snapshots/venial__tests__parse_extern_crate-2.snap
+++ b/src/snapshots/venial__tests__parse_extern_crate-2.snap
@@ -1,0 +1,34 @@
+---
+source: src/tests.rs
+expression: as_crate
+---
+ExternCrate(
+    ExternCrate {
+        attributes: [],
+        vis_marker: None,
+        tk_extern: Ident(
+            extern,
+        ),
+        tk_crate: Ident(
+            crate,
+        ),
+        name: Ident(
+            std,
+        ),
+        tk_as: Some(
+            Ident(
+                as,
+            ),
+        ),
+        alias: Some(
+            Ident(
+                ruststd,
+            ),
+        ),
+        tk_underscore: None,
+        tk_semicolon: Punct {
+            char: ';',
+            spacing: Alone,
+        },
+    },
+)

--- a/src/snapshots/venial__tests__parse_extern_crate-3.snap
+++ b/src/snapshots/venial__tests__parse_extern_crate-3.snap
@@ -1,0 +1,34 @@
+---
+source: src/tests.rs
+expression: as_underscore_crate
+---
+ExternCrate(
+    ExternCrate {
+        attributes: [],
+        vis_marker: None,
+        tk_extern: Ident(
+            extern,
+        ),
+        tk_crate: Ident(
+            crate,
+        ),
+        name: Ident(
+            self,
+        ),
+        tk_as: Some(
+            Ident(
+                as,
+            ),
+        ),
+        alias: Some(
+            Ident(
+                _,
+            ),
+        ),
+        tk_underscore: None,
+        tk_semicolon: Punct {
+            char: ';',
+            spacing: Alone,
+        },
+    },
+)

--- a/src/snapshots/venial__tests__parse_extern_crate.snap
+++ b/src/snapshots/venial__tests__parse_extern_crate.snap
@@ -1,0 +1,26 @@
+---
+source: src/tests.rs
+expression: simple_crate
+---
+ExternCrate(
+    ExternCrate {
+        attributes: [],
+        vis_marker: None,
+        tk_extern: Ident(
+            extern,
+        ),
+        tk_crate: Ident(
+            crate,
+        ),
+        name: Ident(
+            std,
+        ),
+        tk_as: None,
+        alias: None,
+        tk_underscore: None,
+        tk_semicolon: Punct {
+            char: ';',
+            spacing: Alone,
+        },
+    },
+)

--- a/src/snapshots/venial__tests__parse_unsafe_extern_block.snap
+++ b/src/snapshots/venial__tests__parse_unsafe_extern_block.snap
@@ -1,0 +1,22 @@
+---
+source: src/tests.rs
+expression: unsafe_extern
+---
+ExternBlock(
+    ExternBlock {
+        attributes: [],
+        vis_marker: None,
+        tk_unsafe: Some(
+            Ident(
+                unsafe,
+            ),
+        ),
+        tk_extern: Ident(
+            extern,
+        ),
+        extern_abi: None,
+        tk_braces: {},
+        inner_attributes: [],
+        body_items: [],
+    },
+)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -595,18 +595,17 @@ fn parse_complex_enum_variant() {
     assert_debug_snapshot!(enum_type_3);
 }
 
+// Macros in enum item position are illegal in Rust.
 #[test]
-#[should_panic] // FIXME
+#[should_panic]
 fn parse_enum_with_macro() {
-    let enum_decl = parse_declaration(quote!(
+    let _ = parse_declaration(quote!(
         enum Hello {
             A = 1,
             macroified! { B = 2 },
             macroified!(B; 2),
         }
     ));
-
-    assert_debug_snapshot!(enum_decl);
 }
 
 // =================
@@ -943,10 +942,11 @@ fn parse_struct_declaration(tokens: TokenStream) -> Struct {
     }
 }
 
+// Macros in struct field position are illegal in Rust.
 #[test]
-#[should_panic] // FIXME
+#[should_panic]
 fn parse_struct_with_macro() {
-    let struct_decl = parse_struct_declaration(quote!(
+    let _ = parse_struct_declaration(quote!(
         struct Hello {
             a: A,
             b: B,
@@ -955,8 +955,6 @@ fn parse_struct_with_macro() {
             }
         }
     ));
-
-    assert_quote_snapshot!(struct_decl);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1397,3 +1397,53 @@ fn parse_trait_decorated() {
     let trait_decl = parse_declaration_checked(expr);
     assert_debug_snapshot!(trait_decl);
 }
+
+// ====================
+// EXTERN CRATE + BLOCK
+// ====================
+
+#[test]
+fn parse_extern_block() {
+    let filled_extern = quote! {
+        #[decorated]
+        pub(crate) extern "stdcall" {
+           #![allow(unused_variables)]
+
+           some_macro!();
+           fn c_function();
+           static S: i32;
+        }
+    };
+
+    let unsafe_extern = quote! {
+        unsafe extern {}
+    };
+
+    let filled_extern = parse_declaration_checked(filled_extern);
+    assert_debug_snapshot!(filled_extern);
+
+    let unsafe_extern = parse_declaration_checked(unsafe_extern);
+    assert_debug_snapshot!(unsafe_extern);
+}
+
+#[test]
+fn parse_extern_crate() {
+    let simple_crate = quote! {
+        extern crate std;
+    };
+    let as_crate = quote! {
+        extern crate std as ruststd;
+    };
+    let as_underscore_crate = quote! {
+        extern crate self as _;
+    };
+
+    let simple_crate = parse_declaration_checked(simple_crate);
+    assert_debug_snapshot!(simple_crate);
+
+    let as_crate = parse_declaration_checked(as_crate);
+    assert_debug_snapshot!(as_crate);
+
+    let as_underscore_crate = parse_declaration_checked(as_underscore_crate);
+    assert_debug_snapshot!(as_underscore_crate);
+}

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -26,6 +26,8 @@ impl Declaration {
             Declaration::Constant(const_decl) => &const_decl.attributes,
             Declaration::Use(use_decl) => &use_decl.attributes,
             Declaration::Macro(macro_decl) => &macro_decl.attributes,
+            Declaration::ExternBlock(block_decl) => &block_decl.attributes,
+            Declaration::ExternCrate(crate_decl) => &crate_decl.attributes,
         }
     }
 
@@ -45,6 +47,8 @@ impl Declaration {
             Declaration::Constant(const_decl) => &mut const_decl.attributes,
             Declaration::Use(use_decl) => &mut use_decl.attributes,
             Declaration::Macro(macro_decl) => &mut macro_decl.attributes,
+            Declaration::ExternBlock(block_decl) => &mut block_decl.attributes,
+            Declaration::ExternCrate(crate_decl) => &mut crate_decl.attributes,
         }
     }
 
@@ -69,6 +73,8 @@ impl Declaration {
             Declaration::Constant(_) => None,
             Declaration::Use(_) => None,
             Declaration::Macro(_) => None,
+            Declaration::ExternBlock(_) => None,
+            Declaration::ExternCrate(_) => None,
         }
     }
 
@@ -93,6 +99,8 @@ impl Declaration {
             Declaration::Constant(_) => None,
             Declaration::Use(_) => None,
             Declaration::Macro(_) => None,
+            Declaration::ExternBlock(_) => None,
+            Declaration::ExternCrate(_) => None,
         }
     }
 
@@ -122,6 +130,8 @@ impl Declaration {
             Declaration::Constant(const_decl) => Some(const_decl.name.clone()),
             Declaration::Use(_) => None,
             Declaration::Macro(macro_) => Some(macro_.name.clone()),
+            Declaration::ExternBlock(_) => None,
+            Declaration::ExternCrate(crate_) => Some(crate_.name.clone()),
         }
     }
 


### PR DESCRIPTION
To reuse code, it makes parsing of some existing symbols slightly more lenient (e.g. `impl` can also contain `extern`). If this is undesired, we can add some code to handle those (preferrably outside this PR, to keep changes small at a time).