### PR TITLE
Support for lifetimes in receiver parameters

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -9,8 +9,7 @@ use crate::parse_type::{
     parse_named_fields, parse_tuple_fields,
 };
 use crate::parse_utils::{consume_outer_attributes, consume_punct, consume_vis_marker};
-use crate::types::{Enum, Fields, Item, Struct, Union};
-use crate::types_edition::GroupSpan;
+use crate::types::{Enum, Fields, GroupSpan, Item, Struct, Union};
 use proc_macro2::token_stream::IntoIter;
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
 use std::iter::Peekable;

--- a/src/parse_fn.rs
+++ b/src/parse_fn.rs
@@ -1,5 +1,6 @@
 use crate::parse_type::{
-    consume_field_type, consume_generic_params, consume_item_name, consume_where_clause,
+    consume_field_type, consume_generic_params, consume_item_name, consume_lifetime,
+    consume_where_clause,
 };
 use crate::parse_utils::{
     consume_any_ident, consume_comma, consume_ident, consume_outer_attributes, consume_punct,
@@ -79,6 +80,7 @@ fn parse_fn_params(tokens: TokenStream) -> Punctuated<FnParam> {
         let attributes = consume_outer_attributes(&mut tokens);
 
         let tk_ref = consume_punct(&mut tokens, '&');
+        let lifetime = consume_lifetime(&mut tokens, false);
         let tk_mut = consume_ident(&mut tokens, "mut");
         let tk_self = consume_ident(&mut tokens, "self");
 
@@ -86,6 +88,7 @@ fn parse_fn_params(tokens: TokenStream) -> Punctuated<FnParam> {
             FnParam::Receiver(FnReceiverParam {
                 attributes,
                 tk_ref,
+                lifetime,
                 tk_mut,
                 tk_self,
             })

--- a/src/parse_impl.rs
+++ b/src/parse_impl.rs
@@ -6,9 +6,10 @@ use crate::parse_utils::{
     consume_ident, consume_inner_attributes, consume_outer_attributes, consume_punct,
     consume_stuff_until, consume_vis_marker, parse_any_ident, parse_ident, parse_punct,
 };
-use crate::types::{Constant, ImplMember, TypeAlias, ValueExpr};
-use crate::types_edition::GroupSpan;
-use crate::{Attribute, Impl, Item, Trait, TraitMember, TypeExpr, VisMarker};
+use crate::types::{
+    Attribute, Constant, GroupSpan, Impl, ImplMember, Item, Trait, TraitMember, TypeAlias,
+    TypeExpr, ValueExpr, VisMarker,
+};
 use proc_macro2::{Delimiter, Group, TokenTree};
 use quote::ToTokens;
 use std::iter::Peekable;

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,6 +1,5 @@
 use crate::parse_type::consume_generic_args;
-use crate::types::{Attribute, AttributeValue, Path, PathSegment, VisMarker};
-use crate::types_edition::GroupSpan;
+use crate::types::{Attribute, AttributeValue, GroupSpan, Path, PathSegment, VisMarker};
 use proc_macro2::{Delimiter, Ident, Punct, Spacing, TokenStream, TokenTree};
 use std::iter::Peekable;
 

--- a/src/snapshots/venial__tests__interpret_ty_expr_generic_as_path.snap
+++ b/src/snapshots/venial__tests__interpret_ty_expr_generic_as_path.snap
@@ -23,13 +23,15 @@ Path {
             generic_args: GenericArgList {
                 args: [
                     Lifetime {
-                        tk_lifetime: Punct {
-                            char: '\'',
-                            spacing: Joint,
+                        lifetime: Lifetime {
+                            tk_apostrophe: Punct {
+                                char: '\'',
+                                spacing: Joint,
+                            },
+                            name: Ident(
+                                a,
+                            ),
                         },
-                        ident: Ident(
-                            a,
-                        ),
                     },
                     TypeOrConst {
                         expr: [

--- a/src/snapshots/venial__tests__parse_fn_mut_receiver_lifetime.snap
+++ b/src/snapshots/venial__tests__parse_fn_mut_receiver_lifetime.snap
@@ -1,0 +1,76 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        qualifiers: FnQualifiers {
+            tk_default: None,
+            tk_const: None,
+            tk_async: None,
+            tk_unsafe: None,
+            tk_extern: None,
+            extern_abi: None,
+        },
+        tk_fn_keyword: Ident(
+            fn,
+        ),
+        name: Ident(
+            prototype,
+        ),
+        generic_params: Some(
+            [
+                GenericParam {
+                    tk_prefix: "'",
+                    name: "a",
+                    bound: None,
+                },
+            ],
+        ),
+        tk_params_parens: (),
+        params: [
+            Receiver(
+                FnReceiverParam {
+                    attributes: [],
+                    tk_ref: Some(
+                        Punct {
+                            char: '&',
+                            spacing: Alone,
+                        },
+                    ),
+                    lifetime: Some(
+                        Lifetime {
+                            tk_apostrophe: Punct {
+                                char: '\'',
+                                spacing: Joint,
+                            },
+                            name: Ident(
+                                a,
+                            ),
+                        },
+                    ),
+                    tk_mut: Some(
+                        Ident(
+                            mut,
+                        ),
+                    ),
+                    tk_self: Ident(
+                        self,
+                    ),
+                },
+            ),
+        ],
+        where_clause: None,
+        tk_return_arrow: None,
+        return_ty: None,
+        tk_semicolon: Some(
+            Punct {
+                char: ';',
+                spacing: Alone,
+            },
+        ),
+        body: None,
+    },
+)

--- a/src/snapshots/venial__tests__parse_fn_receiver_lifetime.snap
+++ b/src/snapshots/venial__tests__parse_fn_receiver_lifetime.snap
@@ -1,0 +1,64 @@
+---
+source: src/tests.rs
+expression: func
+---
+Function(
+    Function {
+        attributes: [],
+        vis_marker: None,
+        qualifiers: FnQualifiers {
+            tk_default: None,
+            tk_const: None,
+            tk_async: None,
+            tk_unsafe: None,
+            tk_extern: None,
+            extern_abi: None,
+        },
+        tk_fn_keyword: Ident(
+            fn,
+        ),
+        name: Ident(
+            prototype,
+        ),
+        generic_params: None,
+        tk_params_parens: (),
+        params: [
+            Receiver(
+                FnReceiverParam {
+                    attributes: [],
+                    tk_ref: Some(
+                        Punct {
+                            char: '&',
+                            spacing: Alone,
+                        },
+                    ),
+                    lifetime: Some(
+                        Lifetime {
+                            tk_apostrophe: Punct {
+                                char: '\'',
+                                spacing: Joint,
+                            },
+                            name: Ident(
+                                lifetime,
+                            ),
+                        },
+                    ),
+                    tk_mut: None,
+                    tk_self: Ident(
+                        self,
+                    ),
+                },
+            ),
+        ],
+        where_clause: None,
+        tk_return_arrow: None,
+        return_ty: None,
+        tk_semicolon: Some(
+            Punct {
+                char: ';',
+                spacing: Alone,
+            },
+        ),
+        body: None,
+    },
+)

--- a/src/snapshots/venial__tests__parse_fn_self_param-2.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-2.snap
@@ -33,6 +33,7 @@ Ok(
                                 spacing: Alone,
                             },
                         ),
+                        lifetime: None,
                         tk_mut: None,
                         tk_self: Ident(
                             self,

--- a/src/snapshots/venial__tests__parse_fn_self_param-3.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-3.snap
@@ -28,6 +28,7 @@ Ok(
                     FnReceiverParam {
                         attributes: [],
                         tk_ref: None,
+                        lifetime: None,
                         tk_mut: Some(
                             Ident(
                                 mut,

--- a/src/snapshots/venial__tests__parse_fn_self_param-4.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param-4.snap
@@ -33,6 +33,7 @@ Ok(
                                 spacing: Alone,
                             },
                         ),
+                        lifetime: None,
                         tk_mut: Some(
                             Ident(
                                 mut,

--- a/src/snapshots/venial__tests__parse_fn_self_param.snap
+++ b/src/snapshots/venial__tests__parse_fn_self_param.snap
@@ -28,6 +28,7 @@ Ok(
                     FnReceiverParam {
                         attributes: [],
                         tk_ref: None,
+                        lifetime: None,
                         tk_mut: None,
                         tk_self: Ident(
                             self,

--- a/src/snapshots/venial__tests__parse_generic_args.snap
+++ b/src/snapshots/venial__tests__parse_generic_args.snap
@@ -5,13 +5,15 @@ expression: generic_args
 GenericArgList {
     args: [
         Lifetime {
-            tk_lifetime: Punct {
-                char: '\'',
-                spacing: Joint,
+            lifetime: Lifetime {
+                tk_apostrophe: Punct {
+                    char: '\'',
+                    spacing: Joint,
+                },
+                name: Ident(
+                    a,
+                ),
             },
-            ident: Ident(
-                a,
-            ),
         },
         TypeOrConst {
             expr: [

--- a/src/snapshots/venial__tests__parse_impl_inherent.snap
+++ b/src/snapshots/venial__tests__parse_impl_inherent.snap
@@ -182,6 +182,7 @@ Impl(
                                         spacing: Alone,
                                     },
                                 ),
+                                lifetime: None,
                                 tk_mut: Some(
                                     Ident(
                                         mut,

--- a/src/snapshots/venial__tests__parse_impl_trait.snap
+++ b/src/snapshots/venial__tests__parse_impl_trait.snap
@@ -264,6 +264,7 @@ Impl(
                                         spacing: Alone,
                                     },
                                 ),
+                                lifetime: None,
                                 tk_mut: Some(
                                     Ident(
                                         mut,

--- a/src/snapshots/venial__tests__parse_inline_generic_args-2.snap
+++ b/src/snapshots/venial__tests__parse_inline_generic_args-2.snap
@@ -5,13 +5,15 @@ expression: owned_args
 GenericArgList {
     args: [
         Lifetime {
-            tk_lifetime: Punct {
-                char: '\'',
-                spacing: Joint,
+            lifetime: Lifetime {
+                tk_apostrophe: Punct {
+                    char: '\'',
+                    spacing: Joint,
+                },
+                name: Ident(
+                    a,
+                ),
             },
-            ident: Ident(
-                a,
-            ),
         },
         TypeOrConst {
             expr: [

--- a/src/snapshots/venial__tests__parse_trait_simple.snap
+++ b/src/snapshots/venial__tests__parse_trait_simple.snap
@@ -68,6 +68,7 @@ Trait(
                                         spacing: Alone,
                                     },
                                 ),
+                                lifetime: None,
                                 tk_mut: None,
                                 tk_self: Ident(
                                     self,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -874,6 +874,26 @@ fn parse_fn_lifetimes() {
     assert_debug_snapshot!(func);
 }
 
+#[test]
+fn parse_fn_receiver_lifetime() {
+    let func = parse_item(quote!(
+        fn prototype(&'lifetime self);
+    ))
+    .unwrap();
+
+    assert_debug_snapshot!(func);
+}
+
+#[test]
+fn parse_fn_mut_receiver_lifetime() {
+    let func = parse_item(quote!(
+        fn prototype<'a>(&'a mut self);
+    ))
+    .unwrap();
+
+    assert_debug_snapshot!(func);
+}
+
 // FIXME
 #[test]
 #[should_panic]

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -1,11 +1,10 @@
 use crate::parse_utils::{consume_path, tokens_from_slice};
-pub use crate::types::{
-    Attribute, AttributeValue, Enum, EnumVariant, EnumVariantValue, Fields, Function, GenericBound,
-    GenericParam, GenericParamList, GroupSpan, InlineGenericArgs, Item, NamedField, Struct,
-    TupleField, TypeExpr, Union, VisMarker, WhereClause, WhereClausePredicate,
+use crate::types::{
+    Attribute, AttributeValue, Constant, Enum, EnumVariant, EnumVariantValue, Fields, FnQualifiers,
+    Function, GenericArg, GenericArgList, GenericBound, GenericParam, GenericParamList, GroupSpan,
+    Impl, InlineGenericArgs, Item, Lifetime, Module, NamedField, Path, Punctuated, Struct, Trait,
+    TupleField, TypeAlias, TypeExpr, Union, VisMarker, WhereClause, WhereClausePredicate,
 };
-use crate::types::{FnQualifiers, GenericArg, GenericArgList, Impl, Module, Path};
-use crate::{Constant, Punctuated, Trait, TypeAlias};
 use proc_macro2::{Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use quote::spanned::Spanned;
 
@@ -678,8 +677,10 @@ impl<'a> InlineGenericArgs<'a> {
                         let arg = match &param.tk_prefix {
                             Some(TokenTree::Punct(punct)) if punct.as_char() == '\'' => {
                                 GenericArg::Lifetime {
-                                    tk_lifetime: punct.clone(),
-                                    ident: name,
+                                    lifetime: Lifetime {
+                                        tk_apostrophe: punct.clone(),
+                                        name,
+                                    },
                                 }
                             }
                             Some(TokenTree::Ident(ident)) if ident == "const" => {

--- a/src/types_edition.rs
+++ b/src/types_edition.rs
@@ -1,9 +1,10 @@
 use crate::parse_utils::{consume_path, tokens_from_slice};
 use crate::types::{
-    Attribute, AttributeValue, Constant, Enum, EnumVariant, EnumVariantValue, Fields, FnQualifiers,
-    Function, GenericArg, GenericArgList, GenericBound, GenericParam, GenericParamList, GroupSpan,
-    Impl, InlineGenericArgs, Item, Lifetime, Module, NamedField, Path, Punctuated, Struct, Trait,
-    TupleField, TypeAlias, TypeExpr, Union, VisMarker, WhereClause, WhereClausePredicate,
+    Attribute, AttributeValue, Constant, Enum, EnumVariant, EnumVariantValue, ExternBlock,
+    ExternCrate, Fields, FnQualifiers, Function, GenericArg, GenericArgList, GenericBound,
+    GenericParam, GenericParamList, GroupSpan, Impl, InlineGenericArgs, Item, Lifetime, Macro,
+    Module, NamedField, Path, Punctuated, Struct, Trait, TupleField, TypeAlias, TypeExpr, Union,
+    UseDeclaration, VisMarker, WhereClause, WhereClausePredicate,
 };
 use proc_macro2::{Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use quote::spanned::Spanned;
@@ -183,7 +184,7 @@ impl Item {
     }
 
     /// Returns the [`TypeAlias`] variant of the enum if possible.
-    pub fn as_ty_definition(&self) -> Option<&TypeAlias> {
+    pub fn as_type_alias(&self) -> Option<&TypeAlias> {
         match self {
             Item::TypeAlias(ty_decl) => Some(ty_decl),
             _ => None,
@@ -202,6 +203,38 @@ impl Item {
     pub fn as_constant(&self) -> Option<&Constant> {
         match self {
             Item::Constant(const_decl) => Some(const_decl),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`UseDeclaration`] variant of the enum if possible.
+    pub fn as_use_declaration(&self) -> Option<&UseDeclaration> {
+        match self {
+            Item::UseDeclaration(use_decl) => Some(use_decl),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`Macro`] variant of the enum if possible.
+    pub fn as_macro(&self) -> Option<&Macro> {
+        match self {
+            Item::Macro(macro_decl) => Some(macro_decl),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`ExternBlock`] variant of the enum if possible.
+    pub fn as_extern_block(&self) -> Option<&ExternBlock> {
+        match self {
+            Item::ExternBlock(block_decl) => Some(block_decl),
+            _ => None,
+        }
+    }
+
+    /// Returns the [`ExternCrate`] variant of the enum if possible.
+    pub fn as_extern_crate(&self) -> Option<&ExternCrate> {
+        match self {
+            Item::ExternCrate(crate_decl) => Some(crate_decl),
             _ => None,
         }
     }


### PR DESCRIPTION
Adds support for lifetimes in function receiver parameters:
```rs
fn method(&'a self);
fn prototype<'b>(&'b mut self);
```

This adds a new type `Lifetime` which is also reused in `GenericArg`. I thought that makes more sense than separate `(Punct, Ident)` tuples, as I could also imagine to add some utility parsing functions in the future. Let me know what you think. 

Based on #55, the interesting diff is [here, in 2 commits](https://github.com/PoignardAzur/venial/pull/56/files/6ec1ad7a9e36c1c646da907070a6a1456b179f81..4aba53aedbb97d1056be976f790e1401ed34eaa3).