### PR TITLE
Fix `TypeExpr::as_path()` when used as `:ty` in decl-macros

### DIFF
--- a/src/snapshots/venial__tests__interpret_ty_expr_from_declarative_macro.snap
+++ b/src/snapshots/venial__tests__interpret_ty_expr_from_declarative_macro.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests.rs
+expression: path
+---
+Path {
+    segments: [
+        PathSegment {
+            ident: Ident(
+                path,
+            ),
+        },
+        PathSegment {
+            tk_separator_colons: "::",
+            ident: Ident(
+                to,
+            ),
+        },
+        PathSegment {
+            tk_separator_colons: "::",
+            ident: Ident(
+                Type,
+            ),
+        },
+    ],
+}


### PR DESCRIPTION
When using a declarative macro that expands to code using a proc-macro attribute call, such as...
```rs
macro_rules! declarative_macro {
    ($Type:ty) => {
        #[proc_macro]
        impl Trait for $Type;
    };
}
```
...then the `:ty` variable is substituted not as a flat list of the input tokens, but as a `Group` with `separator=None` that contains the tokens as children.

That causes an issue in `TypeExpr::as_path()`, which cannot recognize such a path anymore. This PR unpacks the flat list inside `as_path()`, fixing it.

See details in downstream issue https://github.com/godot-rust/gdext/issues/996#issuecomment-2578181616.