### PR TITLE
Error regarding complex enum variant now provides span

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,7 +33,10 @@ use std::fmt::{Debug, Display};
 ///     let parse_res = match input {
 ///         Err(error) => Err(error),
 ///         Ok(Item::Struct(struct_decl)) => parse_my_struct(struct_decl),
-///         Ok(_) => Err(Error::new("Error in my_derive macro: only structs are accepted")),
+///         Ok(item) => Err(Error::new_at_span(
+///             item.span(),
+///             "Error in my_derive macro: only structs are accepted"
+///         )),
 ///     };
 ///
 ///     parse_res

--- a/src/parse_type.rs
+++ b/src/parse_type.rs
@@ -311,7 +311,10 @@ pub(crate) fn consume_enum_discriminant(
     match tokens.peek() {
         None => (),
         Some(TokenTree::Punct(punct)) if punct.as_char() == ',' => (),
-        Some(_token) => return Err(Error::new("Complex values for enum variants are not supported unless they are between parentheses.")),
+        Some(_token) => {
+            let span = value_token.span();
+            return Err(Error::new_at_span(span,"Complex values for enum variants are not supported unless they are between parentheses."));
+        }
     }
 
     Ok(Some(EnumVariantValue {


### PR DESCRIPTION
Before this PR:

![image](https://github.com/user-attachments/assets/7d82525d-20fd-4374-8562-eb92fd92d8df)

<br>After:

![image](https://github.com/user-attachments/assets/24bc0d28-2c8c-45e9-b4c0-6c308ca4672f)
